### PR TITLE
Remove dependence on unstable features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ regex = "^1.0"
 termcolor = "^0.3.6"
 pathdiff = "^0.1.0"
 textwrap = { version = "^0.10.0", features = ["term_size"] }
+clap = "^2.32.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ termcolor = "^0.3.6"
 pathdiff = "^0.1.0"
 textwrap = { version = "^0.10.0", features = ["term_size"] }
 clap = "^2.32.0"
+
+[features]
+default = ["nightly"]
+nightly = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ textwrap = { version = "^0.10.0", features = ["term_size"] }
 clap = "^2.32.0"
 
 [features]
-default = ["nightly"]
+default = []
 nightly = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ textwrap = { version = "^0.10.0", features = ["term_size"] }
 clap = "^2.32.0"
 
 [features]
-default = []
+default = ["nightly"]
 nightly = []

--- a/features/test.feature
+++ b/features/test.feature
@@ -3,3 +3,7 @@ Feature: Basic functionality
   Scenario: foo
     Given a thing
     When nothing
+
+  Scenario: bar
+    Given a thing
+    When something goes wrong

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,36 @@
+use clap::{Arg, App};
+use regex::Regex;
+
+#[derive(Debug)]
+pub enum CliError {
+    InvalidFilterRegex
+}
+
+pub struct CliOptions {
+    pub filter: Option<Regex>
+}
+
+pub fn make_app<'a, 'b>() -> Result<CliOptions, CliError> {
+    let matches = App::new("cucumber")
+        .version(env!("CARGO_PKG_VERSION"))
+        .author("Brendan Molloy <brendan@bbqsrc.net>")
+        .about("Run the tests, pet a dog!")
+        .arg(Arg::with_name("filter")
+            .short("f")
+            .long("filter")
+            .value_name("regex")
+            .help("Regex to select scenarios from")
+            .takes_value(true))
+        .get_matches();
+
+    let filter = if let Some(filter) = matches.value_of("filter") {
+        let regex = Regex::new(filter).map_err(|_| CliError::InvalidFilterRegex)?;
+        Some(regex)
+    } else {
+        None
+    };
+
+    Ok(CliOptions {
+        filter: filter
+    })
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,8 @@ pub enum CliError {
 }
 
 pub struct CliOptions {
-    pub filter: Option<Regex>
+    pub filter: Option<Regex>,
+    pub suppress_output: bool,
 }
 
 pub fn make_app<'a, 'b>() -> Result<CliOptions, CliError> {
@@ -21,6 +22,9 @@ pub fn make_app<'a, 'b>() -> Result<CliOptions, CliError> {
             .value_name("regex")
             .help("Regex to select scenarios from")
             .takes_value(true))
+        .arg(Arg::with_name("nocapture")
+            .long("nocapture")
+            .help("Use this flag to disable suppression of output from tests"))
         .get_matches();
 
     let filter = if let Some(filter) = matches.value_of("filter") {
@@ -30,7 +34,10 @@ pub fn make_app<'a, 'b>() -> Result<CliOptions, CliError> {
         None
     };
 
+    let suppress_output = cfg!(feature = "nightly") && !matches.is_present("nocapture");
+
     Ok(CliOptions {
-        filter: filter
+        filter: filter,
+        suppress_output: suppress_output,
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,8 @@ use std::any::Any;
 mod output;
 pub mod cli;
 
-pub use output::{DefaultOutput, OutputVisitor};
+use output::OutputVisitor;
+pub use output::default::DefaultOutput;
 
 pub trait World: Default {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,8 +245,8 @@ impl<'s, T: Default> Steps<'s, T> {
         &'s self,
         feature: &'a gherkin::Feature,
         scenario: &'a gherkin::Scenario,
-        before_fns: Option<&[fn(&Scenario) -> ()]>,
-        after_fns: Option<&[fn(&Scenario) -> ()]>,
+        before_fns: &'a Option<&[fn(&Scenario) -> ()]>,
+        after_fns: &'a Option<&[fn(&Scenario) -> ()]>,
         last_panic: Arc<Mutex<Option<PanicDetails>>>,
         output: &mut impl OutputVisitor
     ) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(set_stdio)]
-
 pub extern crate gherkin_rust as gherkin;
 pub extern crate regex;
 extern crate termcolor;
@@ -21,13 +19,11 @@ use regex::Regex;
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::hash::{Hash, Hasher};
-use std::io;
 use std::io::prelude::*;
 use std::ops::Deref;
 use std::panic;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use std::any::Any;
 
 mod output;
 pub mod cli;
@@ -70,7 +66,6 @@ pub struct TestCase<T: Default> {
 }
 
 impl<T: Default> TestCase<T> {
-    #[allow(dead_code)]
     pub fn new(test: TestFn<T>) -> TestCase<T> {
         TestCase {
             test: test
@@ -84,7 +79,6 @@ pub struct RegexTestCase<'a, T: 'a + Default> {
 }
 
 impl<'a, T: Default> RegexTestCase<'a, T> {
-    #[allow(dead_code)]
     pub fn new(test: TestRegexFn<T>) -> RegexTestCase<'a, T> {
         RegexTestCase {
             test: test,
@@ -116,51 +110,38 @@ pub enum TestResult {
     Skipped,
     Unimplemented,
     Pass,
-    Fail(String, String)
+    Fail(PanicDetails)
 }
 
-struct Sink(Arc<Mutex<Vec<u8>>>);
-impl Write for Sink {
-    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-        Write::write(&mut *self.0.lock().unwrap(), data)
+#[derive(Clone)]
+pub struct PanicDetails {
+    pub payload: String,
+    pub location: String,
+}
+
+impl PanicDetails {
+    fn from_panic_info(info: &panic::PanicInfo) -> PanicDetails {
+        let info_payload = info.payload();
+        let payload = if let Some(s) = info_payload.downcast_ref::<String>() {
+            s.clone()
+        } else if let Some(s) = info_payload.downcast_ref::<&str>() {
+            s.deref().to_owned()
+        } else {
+            "Opaque panic payload".to_owned()
+        };
+
+        let location = info.location()
+                .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
+                .unwrap_or("Unknown location".to_owned());
+
+        PanicDetails {
+            payload,
+            location,
+        }
     }
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
 }
-
-struct CapturedIo<T> {
-    stdout: Vec<u8>,
-    result: Result<T, Box<dyn Any + Send>>
-}
-
-fn capture_io<T, F: FnOnce() -> T>(callback: F) -> CapturedIo<T> {
-    let data = Arc::new(Mutex::new(Vec::new()));
-    let data2 = data.clone();
-
-    let old_io = (
-        io::set_print(Some(Box::new(Sink(data2.clone())))),
-        io::set_panic(Some(Box::new(Sink(data2))))
-    );
-
-    let result = panic::catch_unwind(
-        panic::AssertUnwindSafe(callback)
-    );
-
-    let captured_io = CapturedIo {
-        stdout: data.lock().unwrap().to_vec(),
-        result: result
-    };
-
-    io::set_print(old_io.0);
-    io::set_panic(old_io.1);
-
-    captured_io
-}
-
 
 impl<'s, T: Default> Steps<'s, T> {
-    #[allow(dead_code)]
     pub fn new() -> Steps<'s, T> {
         let regex_tests = RegexSteps {
             given: HashMap::new(),
@@ -168,14 +149,12 @@ impl<'s, T: Default> Steps<'s, T> {
             then: HashMap::new()
         };
 
-        let tests = Steps {
+        Steps {
             given: HashMap::new(),
             when: HashMap::new(),
             then: HashMap::new(),
             regex: regex_tests
-        };
-
-        tests
+        }
     }
 
     fn test_bag_for<'a>(&self, ty: StepType) -> &HashMap<&'static str, TestCase<T>> {
@@ -231,50 +210,32 @@ impl<'s, T: Default> Steps<'s, T> {
         };
     }
 
-    fn run_test<'a>(&'s self, world: &mut T, test_type: TestCaseType<'s, T>, step: &'a Step, last_panic: Arc<Mutex<Option<String>>>) -> TestResult {
+    fn run_test<'a>(&'s self, world: &mut T, test_type: TestCaseType<'s, T>, step: &'a Step, last_panic: Arc<Mutex<Option<PanicDetails>>>) -> TestResult {
         let last_panic_hook = last_panic.clone();
         panic::set_hook(Box::new(move |info| {
             let mut state = last_panic.lock().expect("last_panic unpoisoned");
-            *state = info.location().map(|x| format!("{}:{}:{}", x.file(), x.line(), x.column()));
+            *state = Some(PanicDetails::from_panic_info(info));
         }));
 
 
-        let captured_io = capture_io(move || {
+        let test_result = panic::catch_unwind(panic::AssertUnwindSafe(move || {
             self.run_test_inner(world, test_type, &step)
-        });
+        }));
 
         let _ = panic::take_hook();
         
-        match captured_io.result {
+        match test_result {
             Ok(_) => TestResult::Pass,
-            Err(any) => {
-                let mut state = last_panic_hook.lock().expect("unpoisoned");
-                let loc = match &*state {
-                    Some(v) => &v,
-                    None => "unknown"
-                };
+            Err(_) => {
+                let panic_info = last_panic_hook.lock()
+                    .expect("unpoisoned")
+                    .clone()
+                    .expect("Panic occurred during test but panic info was not caught");
 
-                let s = {
-                    if let Some(s) = any.downcast_ref::<String>() {
-                        s.as_str()
-                    } else if let Some(s) = any.downcast_ref::<&str>() {
-                        *s
-                    } else {
-                        ""
-                    }
-                };
-
-                if s.ends_with("test skipped") {
-                    TestResult::Skipped
+                if panic_info.payload == "not yet implemented" {
+                    TestResult::Unimplemented
                 } else {
-                    let mut m = format!("Panicked with: {}", s);
-
-                    if &captured_io.stdout.len() > &0usize {
-                        m.push_str("\n\n");
-                        m.push_str(&String::from_utf8_lossy(&captured_io.stdout));
-                    }
-
-                    TestResult::Fail(m, loc.to_owned())
+                    TestResult::Fail(panic_info)
                 }
             }
         }
@@ -284,34 +245,16 @@ impl<'s, T: Default> Steps<'s, T> {
         &'s self,
         feature: &'a gherkin::Feature,
         scenario: &'a gherkin::Scenario,
-        before_fns: &'a Option<&[fn(&Scenario) -> ()]>,
-        after_fns: &'a Option<&[fn(&Scenario) -> ()]>,
-        last_panic: Arc<Mutex<Option<String>>>,
+        before_fns: Option<&[fn(&Scenario) -> ()]>,
+        after_fns: Option<&[fn(&Scenario) -> ()]>,
+        last_panic: Arc<Mutex<Option<PanicDetails>>>,
         output: &mut impl OutputVisitor
     ) -> bool {
         output.visit_scenario(&scenario);
 
         let mut has_failures = false;
 
-        let captured_io = capture_io(|| T::default());
-        let mut world = match captured_io.result {
-            Ok(v) => v,
-            Err(e) => {
-                eprintln!("An error occurred creating world:");
-                if &captured_io.stdout.len() > &0usize {
-                    let msg = String::from_utf8_lossy(&captured_io.stdout).to_string();
-                    panic!(msg);
-                } else {
-                    panic!(e);
-                }
-            }
-        };
-
-        if let Some(before_fns) = before_fns {
-            for f in before_fns.iter() {
-                f(&scenario);
-            }
-        }
+        let mut world = T::default();
 
         let mut steps: Vec<&'a Step> = vec![];
         if let Some(ref bg) = &feature.background {
@@ -347,11 +290,11 @@ impl<'s, T: Default> Steps<'s, T> {
                 let result = self.run_test(&mut world, test_type, &step, last_panic.clone());
                 output.visit_step_result(&scenario, &step, &result);
                 match result {
-                    TestResult::Pass => {}
-                    TestResult::Fail(_, _) => {
+                    TestResult::Pass => {},
+                    TestResult::Fail(_) => { 
                         has_failures = true;
                         is_skipping = true;
-                    }
+                    },
                     _ => {
                         is_skipping = true;
                         output.visit_scenario_skipped(&scenario);
@@ -382,7 +325,7 @@ impl<'s, T: Default> Steps<'s, T> {
         output.visit_start();
         
         let feature_path = fs::read_dir(feature_path).expect("feature path to exist");
-        let last_panic: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let last_panic: Arc<Mutex<Option<PanicDetails>>> = Arc::new(Mutex::new(None));
         let mut has_failures = false;
 
         for entry in feature_path {

--- a/src/output/default.rs
+++ b/src/output/default.rs
@@ -89,7 +89,7 @@ impl DefaultOutput {
     }
 
     fn println(&mut self, s: &str) {
-        writeln!(&mut self.stdout, "{}", s);
+        writeln!(&mut self.stdout, "{}", s).unwrap();
     }
 
 

--- a/src/output/default.rs
+++ b/src/output/default.rs
@@ -346,19 +346,19 @@ impl OutputVisitor for DefaultOutput {
                 self.writeln_cmt(&format!("✔ {}", msg), cmt, indent, Color::Green, false);
                 self.print_step_extras(step);
             },
-            TestResult::Fail(err_msg, loc) => {
+            TestResult::Fail(panic_info) => {
                 self.writeln_cmt(&format!("✘ {}", msg), cmt, indent, Color::Red, false);
                 self.print_step_extras(step);
                 self.writeln_cmt(
                     &format!(
                         "{:—<1$}", "! Step failed: ",
-                        textwrap::termwidth() - loc.chars().count() - 7
+                        textwrap::termwidth() - panic_info.location.chars().count() - 7
                     ),
-                    loc,
+                    &panic_info.location,
                     "———— ",
                     Color::Red,
                     true);
-                self.red(&textwrap::indent(&textwrap::fill(err_msg, textwrap::termwidth() - 4), "  ").trim_right());
+                self.red(&textwrap::indent(&textwrap::fill(&panic_info.payload, textwrap::termwidth() - 4), "  ").trim_right());
                 self.writeln(&format!("{:—<1$}", "", textwrap::termwidth()), Color::Red, true);
                 self.fail_count += 1;
                 self.scenarios.insert(scenario.clone(), ScenarioResult::Fail);

--- a/src/output/default.rs
+++ b/src/output/default.rs
@@ -346,7 +346,7 @@ impl OutputVisitor for DefaultOutput {
                 self.writeln_cmt(&format!("✔ {}", msg), cmt, indent, Color::Green, false);
                 self.print_step_extras(step);
             },
-            TestResult::Fail(panic_info) => {
+            TestResult::Fail(panic_info, captured_output) => {
                 self.writeln_cmt(&format!("✘ {}", msg), cmt, indent, Color::Red, false);
                 self.print_step_extras(step);
                 self.writeln_cmt(
@@ -359,6 +359,11 @@ impl OutputVisitor for DefaultOutput {
                     Color::Red,
                     true);
                 self.red(&textwrap::indent(&textwrap::fill(&panic_info.payload, textwrap::termwidth() - 4), "  ").trim_right());
+                if captured_output.len() > 0 {
+                    let output_str = String::from_utf8(captured_output.to_vec()).unwrap_or_else(|_| format!("{:?}", captured_output));
+                    self.red(&textwrap::indent(&textwrap::fill("Captured output:", textwrap::termwidth() - 4), "  ").trim_right());
+                    self.red(&textwrap::indent(&textwrap::fill(&output_str, textwrap::termwidth() - 4), "  ").trim_right());
+                }
                 self.writeln(&format!("{:—<1$}", "", textwrap::termwidth()), Color::Red, true);
                 self.fail_count += 1;
                 self.scenarios.insert(scenario.clone(), ScenarioResult::Fail);

--- a/src/output/default.rs
+++ b/src/output/default.rs
@@ -88,6 +88,10 @@ impl DefaultOutput {
         self.stdout.set_color(ColorSpec::new().set_fg(None)).unwrap();
     }
 
+    fn println(&mut self, s: &str) {
+        writeln!(&mut self.stdout, "{}", s);
+    }
+
     fn red(&mut self, s: &str) {
         self.writeln(s, Color::Red, false);
     }
@@ -143,7 +147,7 @@ impl DefaultOutput {
                 self.write(&field, Color::White, true);
                 self.write("|", border_color.clone(), true);
             }
-            println!();
+            self.println("");
 
             for row in formatted_row_fields {
                 print!("{}", indent);
@@ -152,7 +156,7 @@ impl DefaultOutput {
                     print!("{}", field);
                     self.write("|", border_color.clone(), false);
                 }
-                println!();
+                self.println("");
             }
         };
 
@@ -176,7 +180,7 @@ impl DefaultOutput {
             write!(&mut self.stdout, ")")?;
         }
 
-        println!();
+        self.println("");
             
         // Do scenario count
         let scenario_passed_count = self.scenarios.values().filter(|v| {
@@ -226,7 +230,7 @@ impl DefaultOutput {
 
         write!(&mut self.stdout, ")")?;
 
-        println!();
+        self.println("");
 
         // Do steps
         let passed_count = self.step_count - self.skipped_count - self.fail_count;
@@ -256,12 +260,12 @@ impl DefaultOutput {
         write!(&mut self.stdout, "{} passed", passed_count)?;
         self.set_color(Color::White, true);
         write!(&mut self.stdout, ")")?;
-        println!();
+        self.println("");
 
         self.stdout.set_color(ColorSpec::new()
             .set_fg(None)
             .set_bold(false))?;
-        println!();
+        self.println("");
 
         Ok(())
     }
@@ -329,7 +333,7 @@ impl OutputVisitor for DefaultOutput {
         if !self.scenarios.contains_key(scenario) {
             self.scenarios.insert(scenario.clone(), ScenarioResult::Pass);
         }
-        println!();
+        self.println("");
     }
     
     fn visit_step(&mut self, _scenario: &gherkin::Scenario, _step: &gherkin::Step) {
@@ -359,21 +363,22 @@ impl OutputVisitor for DefaultOutput {
                     Color::Red,
                     true);
                 self.red(&textwrap::indent(&textwrap::fill(&panic_info.payload, textwrap::termwidth() - 4), "  ").trim_right());
+
                 if captured_output.len() > 0 {
+                    self.writeln(&format!("{:—<1$}", "———— Captured output: ", textwrap::termwidth()), Color::Red, true);
                     let output_str = String::from_utf8(captured_output.to_vec()).unwrap_or_else(|_| format!("{:?}", captured_output));
-                    self.red(&textwrap::indent(&textwrap::fill("Captured output:", textwrap::termwidth() - 4), "  ").trim_right());
                     self.red(&textwrap::indent(&textwrap::fill(&output_str, textwrap::termwidth() - 4), "  ").trim_right());
                 }
                 self.writeln(&format!("{:—<1$}", "", textwrap::termwidth()), Color::Red, true);
+
                 self.fail_count += 1;
                 self.scenarios.insert(scenario.clone(), ScenarioResult::Fail);
             },
             TestResult::MutexPoisoned => {
                 self.writeln_cmt(&format!("- {}", msg), cmt, indent, Color::Cyan, false);
                 self.print_step_extras(step);
-
                 self.write("    ⚡ ", Color::Yellow, false);
-                println!("Skipped due to previous error (poisoned)");
+                self.println("Skipped due to previous error (poisoned)");
                 self.fail_count += 1;
             },
             TestResult::Skipped => {
@@ -385,7 +390,7 @@ impl OutputVisitor for DefaultOutput {
                 self.writeln_cmt(&format!("- {}", msg), cmt, indent, Color::Cyan, false);
                 self.print_step_extras(step);
                 self.write("    ⚡ ", Color::Yellow, false);
-                println!("Not yet implemented (skipped)");
+                self.println("Not yet implemented (skipped)");
                 
                 self.skipped_count += 1;
             }

--- a/src/output/default.rs
+++ b/src/output/default.rs
@@ -9,18 +9,7 @@ use std::collections::HashMap;
 use textwrap;
 use std;
 
-pub trait OutputVisitor : Default {
-    fn visit_start(&mut self);
-    fn visit_feature(&mut self, feature: &gherkin::Feature, path: &Path);
-    fn visit_feature_end(&mut self, feature: &gherkin::Feature);
-    fn visit_feature_error<'a>(&mut self, path: &Path, error: &gherkin::Error<'a>);
-    fn visit_scenario(&mut self, scenario: &gherkin::Scenario);
-    fn visit_scenario_end(&mut self, scenario: &gherkin::Scenario);
-    fn visit_scenario_skipped(&mut self, scenario: &gherkin::Scenario);
-    fn visit_step(&mut self, scenario: &gherkin::Scenario, step: &gherkin::Step);
-    fn visit_step_result(&mut self, scenario: &gherkin::Scenario, step: &gherkin::Step, result: &TestResult);
-    fn visit_finish(&mut self);
-}
+use OutputVisitor;
 
 enum ScenarioResult {
     Pass,

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,0 +1,19 @@
+pub mod default;
+
+use std::path::Path;
+
+use gherkin;
+use TestResult;
+
+pub trait OutputVisitor : Default {
+    fn visit_start(&mut self);
+    fn visit_feature(&mut self, feature: &gherkin::Feature, path: &Path);
+    fn visit_feature_end(&mut self, feature: &gherkin::Feature);
+    fn visit_feature_error<'a>(&mut self, path: &Path, error: &gherkin::Error<'a>);
+    fn visit_scenario(&mut self, scenario: &gherkin::Scenario);
+    fn visit_scenario_end(&mut self, scenario: &gherkin::Scenario);
+    fn visit_scenario_skipped(&mut self, scenario: &gherkin::Scenario);
+    fn visit_step(&mut self, scenario: &gherkin::Scenario, step: &gherkin::Step);
+    fn visit_step_result(&mut self, scenario: &gherkin::Scenario, step: &gherkin::Step, result: &TestResult);
+    fn visit_finish(&mut self);
+}

--- a/src/panic_trap.rs
+++ b/src/panic_trap.rs
@@ -70,7 +70,7 @@ impl<T> PanicTrap<T> {
         let loud_panic_trap = PanicTrap::run_loudly(f);
 
         io::set_print(old_io.0);
-        io::set_print(old_io.1);
+        io::set_panic(old_io.1);
 
         let stdout = stdout_sink_hook.lock().expect("Stdout mutex poisoned").clone();
         PanicTrap {

--- a/src/panic_trap.rs
+++ b/src/panic_trap.rs
@@ -1,0 +1,108 @@
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+use std::panic;
+use std::ops::Deref;
+
+#[derive(Clone)]
+pub struct PanicDetails {
+    pub payload: String,
+    pub location: String,
+}
+
+impl PanicDetails {
+    fn from_panic_info(info: &panic::PanicInfo) -> PanicDetails {
+        let info_payload = info.payload();
+        let payload = if let Some(s) = info_payload.downcast_ref::<String>() {
+            s.clone()
+        } else if let Some(s) = info_payload.downcast_ref::<&str>() {
+            s.deref().to_owned()
+        } else {
+            "Opaque panic payload".to_owned()
+        };
+
+        let location = info.location()
+                .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
+                .unwrap_or("Unknown location".to_owned());
+
+        PanicDetails {
+            payload,
+            location,
+        }
+    }
+}
+
+#[derive(Default)]
+struct Sink(Arc<Mutex<Vec<u8>>>);
+
+impl Write for Sink {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        Write::write(&mut *self.0.lock().unwrap(), data)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.lock().unwrap().flush()
+    }
+}
+
+pub struct PanicTrap<T> {
+    pub stdout: Vec<u8>,
+    pub result: Result<T, PanicDetails>,
+}
+
+impl<T> PanicTrap<T> {
+    pub fn run<F: FnOnce() -> T>(quiet: bool, f: F) -> PanicTrap<T> {
+        if quiet {
+            PanicTrap::run_quietly(f)
+        } else {
+            PanicTrap::run_loudly(f)
+        }
+    }
+
+    #[cfg(feature = "nightly")]
+    fn run_quietly<F: FnOnce() -> T>(f: F) -> PanicTrap<T> {
+        let stdout_sink = Arc::new(Mutex::new(vec![]));
+        let stdout_sink_hook = stdout_sink.clone();
+        let old_io = (
+            io::set_print(Some(Box::new(Sink(stdout_sink.clone())))),
+            io::set_panic(Some(Box::new(Sink(stdout_sink))))
+        );
+
+        let loud_panic_trap = PanicTrap::run_loudly(f);
+
+        io::set_print(old_io.0);
+        io::set_print(old_io.1);
+
+        let stdout = stdout_sink_hook.lock().expect("Stdout mutex poisoned").clone();
+        PanicTrap {
+            stdout: stdout,
+            result: loud_panic_trap.result,
+        }
+    }
+
+    #[cfg(not(feature = "nightly"))]
+    fn run_quietly<F: FnOnce() -> T>(_f: F) -> PanicTrap<T> {
+        panic!("PanicTrap cannot run quietly without the 'nightly' feature");
+    }
+
+    fn run_loudly<F: FnOnce() -> T>(f: F) -> PanicTrap<T> {
+        let last_panic = Arc::new(Mutex::new(None));
+
+        panic::set_hook({
+            let last_panic_hook = last_panic.clone();
+            Box::new(move |info| {
+                let mut state = last_panic_hook.lock().expect("last_panic unpoisoned");
+                *state = Some(PanicDetails::from_panic_info(info));
+            })
+        });
+
+        let result = panic::catch_unwind(panic::AssertUnwindSafe(f))
+            .map_err(|_| last_panic.lock().expect("Last panic mutex poisoned").clone().expect("Panic occurred but no panic details were set"));
+
+        let _ = panic::take_hook();
+
+        PanicTrap {
+            stdout: vec![],
+            result
+        }
+    }
+}

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -37,6 +37,12 @@ mod basic {
             assert!(true);
         };
 
+        when "something goes wrong" |_world, _step| {
+            println!("Something to stdout");
+            eprintln!("Something to stderr");
+            panic!("This is my custom panic message");
+        };
+
         then "another thing" |_world, _step| {
             assert!(true)
         };

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -42,11 +42,27 @@ mod basic {
         then "another thing" |_world, _step| {
             assert!(true)
         };
-
-        when "nothing" |world, step| {
-            // panic!("oh shit");
-        };
     }
+}
+
+fn before_thing(step: &cucumber_rust::Scenario) {
+
+}
+
+before!(some_before: "@tag2 and @tag3" |scenario| {
+    println!("{}", "lol");
+});
+
+before!(something_great |scenario| {
+
+});
+
+after!(after_thing |scenario| {
+
+});
+
+fn setup() {
+
 }
 
 cucumber! {
@@ -54,5 +70,8 @@ cucumber! {
     world: ::MyWorld;
     steps: &[
         basic::steps
-    ]
+    ];
+    setup: setup;
+    before: &[before_thing, some_before, something_great];
+    after: &[after_thing]
 }

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,5 +1,3 @@
-#![feature(fnbox)]
-
 #[macro_use]
 extern crate cucumber_rust;
 


### PR DESCRIPTION
# Overview

Currently `cucumber-rust` relies on two unstable Rust features: `set_stdio` and `fnbox`. If this PR is accepted then cucumber-rust will be usable on stable Rust instead of nightly.
 
## `set_stdio`

This is used to capture and suppress world construction and step execution. During world construction the output is suppressed and any panic is effectively re-thrown however it actually panics with the combined contents of stdout and stderr. During step execution the is examined if a panic is caught to re-print the panic information and provide prettier panic information.

This PR removes the stdout/stderr suppression entirely. No special panic handling is done during world construction as this panic was already rethrown. During step execution the `PanicInfo` payload is down-casted to a `String` at the same time as building the location information in the panic handler.

Disabling suppression of stdout/stderr could be contentious however this is the same behaviour as the Java cucumber library.

## `fnbox`

This is used during the main function to pass in the `before` function as an optional boxed closure. This is currently defaulted to `None` if there is no `before` function defined. Instead now the default `before` argument is an empty closure and main evaluates the provided closure unconditionally.