### PR TITLE
return empty string instead of panicing on non-existant regex captures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,10 @@ impl<'s, T: Default> Steps<'s, T> {
                 match result {
                     Some((regex, tc)) => {
                         let matches = regex.0.captures(&step.value).unwrap();
-                        let matches: Vec<String> = matches.iter().map(|x| x.unwrap().as_str().to_string()).collect();
+                        let matches: Vec<String> = matches
+                            .iter()
+                            .map(|x| x.map(|s| s.as_str().to_string()).unwrap_or("".to_string()))
+                            .collect();
                         Some(TestCaseType::Regex(tc, matches))
                     },
                     None => {


### PR DESCRIPTION
regexes with optional captures will panic if that capture is not present
in a string, i.e. r"hello( \s)?" will panic on "hello"

another way to handle this would be to return on Option<String> however
that would change the API