### PR TITLE
Use rustc_version to automatically detect Rust nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 repository = "https://github.com/bbqsrc/cucumber-rust"
 documentation = "https://docs.rs/cucumber_rust"
 homepage = "https://github.com/bbqsrc/cucumber-rust"
+build = "build.rs"
 
 [[test]]
 name = "cucumber"
@@ -22,6 +23,8 @@ textwrap = { version = "^0.10.0", features = ["term_size"] }
 clap = "^2.32.0"
 globwalk = "0.5"
 
+[build-dependencies]
+rustc_version = "0.2"
+
 [features]
-default = ["nightly"]
 nightly = []

--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ harness = false # Allows Cucumber to print output instead of libtest
 cucumber_rust = "^0.5.1"
 ```
 
-If using stable Rust, you need to disable the `nightly` feature:
-
-```
-cucumber_rust = { version = "^0.5.1", default-features = false }
-```
-
 Create a directory called `features/` and put a feature file in it named something like `example.feature`. It might look like:
 
 ```gherkin

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+extern crate rustc_version;
+
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    if version_meta().unwrap().channel == Channel::Nightly {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}


### PR DESCRIPTION
Avoid builds failing using stable Rust by automatically detecting Rust
nightly using a build script and the rustc_version crate.