### PR TITLE
Fix eval_order_dependency Clippy warning triggered by steps! macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -632,11 +632,14 @@ macro_rules! steps {
             $crate::HashableRegex($crate::regex::Regex::new($name).expect(&format!("{} is a valid regex", $name))),
                 $crate::RegexTestCase::new(|world: &mut $worldtype, matches, step| {
                     let closure: Box<Fn(&mut $worldtype, $($arg_type,)* &$crate::gherkin::Step) -> ()> = Box::new($body);
+                    let mut matches = matches.into_iter().enumerate();
 
-                    let mut i = 0;
-                    closure(world,
-                        $( matches[{i += 1; i}].parse::<$arg_type>()
-                            .expect(&format!("Failed to parse argument {} '{}' of type {}", i, matches[i], stringify!($arg_type))),)*
+                    closure(
+                        world,
+                        $({
+                            let (index, match_) = matches.next().unwrap();
+                            match_.parse::<$arg_type>().expect(&format!("Failed to parse {}th argument '{}' to type {}", index, match_, stringify!($arg_type)))
+                        },)*
                         step
                     )
                 }));
@@ -650,11 +653,14 @@ macro_rules! steps {
             $crate::HashableRegex($crate::regex::Regex::new($name).expect(&format!("{} is a valid regex", $name))),
                 $crate::RegexTestCase::new(|world: &mut $worldtype, matches, step| {
                     let closure: Box<Fn(&mut $worldtype, $($arg_type,)* &$crate::gherkin::Step) -> ()> = Box::new($body);
-                    
-                    let mut i = 0;
-                    closure(world,
-                        $( matches[{i += 1; i}].parse::<$arg_type>()
-                            .expect(&format!("Failed to parse argument {} '{}' of type {}", i, matches[i], stringify!($arg_type))),)*
+                    let mut matches = matches.into_iter().enumerate().skip(1);
+
+                    closure(
+                        world,
+                        $({
+                            let (index, match_) = matches.next().unwrap();
+                            match_.parse::<$arg_type>().expect(&format!("Failed to parse {}th argument '{}' to type {}", index, match_, stringify!($arg_type)))
+                        },)*
                         step
                     )
                 }));

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -20,10 +20,10 @@ impl Default for MyWorld {
 #[cfg(test)]
 mod basic {
     steps!(::MyWorld => {
-        when regex "thing (\\d+)" (usize) |world, sz, step| {
+        when regex "thing (\\d+) does (.+)" (usize, String) |world, sz, txt, step| {
 
         };
-        
+
         when regex "^test (.*) regex$" |_world, matches, _step| {
             println!("{}", matches[1]);
         };


### PR DESCRIPTION
The steps! macro enumerates the capture groups in a regular expression
using an index that is incremented as well as read within a single
expression triggering the Clippy lint eval_order_dependency [1] in
crates using that macro.

[1] https://rust-lang.github.io/rust-clippy/current/index.html#eval_order_dependence