### PR TITLE
Replace usage of trim_right by trim_end

### DIFF
--- a/src/output/default.rs
+++ b/src/output/default.rs
@@ -166,7 +166,7 @@ impl DefaultOutput {
 
         if let Some(ref docstring) = &step.docstring {
             self.writeln(&format!("{}\"\"\"", indent), Color::Magenta, true);
-            println!("{}", textwrap::indent(docstring, indent).trim_right());
+            println!("{}", textwrap::indent(docstring, indent).trim_end());
             self.writeln(&format!("{}\"\"\"", indent), Color::Magenta, true);
         }
     }
@@ -319,7 +319,7 @@ impl OutputVisitor for DefaultOutput {
                     textwrap::termwidth() - 4
                 ),
                 "  "
-            ).trim_right()
+            ).trim_end()
         );
 
         self.writeln(&format!("{:—<1$}\n", "", textwrap::termwidth()), Color::Red, true);
@@ -381,12 +381,12 @@ impl OutputVisitor for DefaultOutput {
                     "———— ",
                     Color::Red,
                     true);
-                self.red(&textwrap::indent(&textwrap::fill(&panic_info.payload, textwrap::termwidth() - 4), "  ").trim_right());
+                self.red(&textwrap::indent(&textwrap::fill(&panic_info.payload, textwrap::termwidth() - 4), "  ").trim_end());
 
                 if captured_output.len() > 0 {
                     self.writeln(&format!("{:—<1$}", "———— Captured output: ", textwrap::termwidth()), Color::Red, true);
                     let output_str = String::from_utf8(captured_output.to_vec()).unwrap_or_else(|_| format!("{:?}", captured_output));
-                    self.red(&textwrap::indent(&textwrap::fill(&output_str, textwrap::termwidth() - 4), "  ").trim_right());
+                    self.red(&textwrap::indent(&textwrap::fill(&output_str, textwrap::termwidth() - 4), "  ").trim_end());
                 }
                 self.writeln(&format!("{:—<1$}", "", textwrap::termwidth()), Color::Red, true);
 

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -20,7 +20,7 @@ impl Default for MyWorld {
 #[cfg(test)]
 mod basic {
     steps!(::MyWorld => {
-        when regex "thing (\\d+)" (usize) |world, sz, step| {
+        when regex "thing (\\d+)" (usize) |_world, _sz, _step| {
 
         };
         
@@ -52,19 +52,19 @@ mod basic {
     });
 }
 
-fn before_thing(step: &cucumber_rust::Scenario) {
+fn before_thing(_step: &cucumber_rust::Scenario) {
 
 }
 
-before!(some_before: "@tag2 and @tag3" => |scenario| {
+before!(some_before: "@tag2 and @tag3" => |_scenario| {
     println!("{}", "lol");
 });
 
-before!(something_great => |scenario| {
+before!(something_great => |_scenario| {
 
 });
 
-after!(after_thing => |scenario| {
+after!(after_thing => |_scenario| {
 
 });
 


### PR DESCRIPTION
The `trim_right` method is deprecated as it could be confusing for users
of right-to-left scripts and this replaces its usage by calling `trim_end`
instead which makes the current stable rustc version 1.35 happy.