### PR TITLE
Add Travis CI manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+
+language: rust
+
+rust:
+  - stable
+  - nightly
+
+script:
+  - cargo check --verbose --all-targets --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/bbqsrc/cucumber-rust"
 documentation = "https://docs.rs/cucumber_rust"
 homepage = "https://github.com/bbqsrc/cucumber-rust"
 
+[badges]
+travis-ci = { repository = "bbqsrc/cucumber-rust" }
+
 [[test]]
 name = "cucumber"
 harness = false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/bbqsrc/cucumber-rust.svg?branch=master)](https://travis-ci.org/bbqsrc/cucumber-rust)
+
 # cucumber-rust
 
 An implementation of the Cucumber testing framework for Rust. Fully native, no external test runners or dependencies.


### PR DESCRIPTION
Sets up a minimal CI pipeline using publicly available Travis CI service.

The usage of `--no-default-features` can be removed after bbqsrc/cucumber-rust#14 is merged.

`--deny warnings` could be added after bbqsrc/cucumber-rust#16 is merged.