### PR TITLE
Make Clippy happy and deny its warnings during CI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,12 @@ rust:
   - stable
   - nightly
 
+matrix:
+  allow_failures:
+    - rust: nightly
+
+before_script:
+  - rustup component add clippy
+
 script:
-  - cargo check --verbose --all-targets --no-default-features
+  - cargo clippy --verbose --all-targets -- --deny warnings

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,7 +13,7 @@ pub struct CliOptions {
     pub suppress_output: bool,
 }
 
-pub fn make_app<'a, 'b>() -> Result<CliOptions, CliError> {
+pub fn make_app() -> Result<CliOptions, CliError> {
     let matches = App::new("cucumber")
         .version(env!("CARGO_PKG_VERSION"))
         .author("Brendan Molloy <brendan@bbqsrc.net>")

--- a/src/output/default.rs
+++ b/src/output/default.rs
@@ -290,11 +290,11 @@ impl OutputVisitor for DefaultOutput {
         let msg = &format!("Feature: {}", &feature.name);
         let cmt = &format!("{}:{}:{}", &self.cur_feature, feature.position.0, feature.position.1);
         self.bold_white_comment(msg, cmt, "");
-        println!("");
+        println!();
 
         self.feature_count += 1;
     }
-    
+
     fn visit_feature_end(&mut self, _feature: &gherkin::Feature) {}
 
     fn visit_feature_error<'r>(&mut self, path: &Path, error: &gherkin::Error<'r>) {
@@ -361,7 +361,7 @@ impl OutputVisitor for DefaultOutput {
     
     fn visit_step_result(&mut self, rule: Option<&gherkin::Rule>, scenario: &gherkin::Scenario, step: &gherkin::Step, result: &TestResult) {
         let cmt = &format!("{}:{}:{}", &self.cur_feature, step.position.0, step.position.1);
-        let msg = &format!("{}", &step.to_string());
+        let msg = &step.to_string();
         let indent = if rule.is_some() { "   " } else { "  " };
 
         match result {
@@ -383,7 +383,7 @@ impl OutputVisitor for DefaultOutput {
                     true);
                 self.red(&textwrap::indent(&textwrap::fill(&panic_info.payload, textwrap::termwidth() - 4), "  ").trim_end());
 
-                if captured_output.len() > 0 {
+                if !captured_output.is_empty() {
                     self.writeln(&format!("{:—<1$}", "———— Captured output: ", textwrap::termwidth()), Color::Red, true);
                     let output_str = String::from_utf8(captured_output.to_vec()).unwrap_or_else(|_| format!("{:?}", captured_output));
                     self.red(&textwrap::indent(&textwrap::fill(&output_str, textwrap::termwidth() - 4), "  ").trim_end());

--- a/src/panic_trap.rs
+++ b/src/panic_trap.rs
@@ -22,7 +22,7 @@ impl PanicDetails {
 
         let location = info.location()
                 .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
-                .unwrap_or("Unknown location".to_owned());
+                .unwrap_or_else(|| "Unknown location".to_owned());
 
         PanicDetails {
             payload,
@@ -74,7 +74,7 @@ impl<T> PanicTrap<T> {
 
         let stdout = stdout_sink_hook.lock().expect("Stdout mutex poisoned").clone();
         PanicTrap {
-            stdout: stdout,
+            stdout,
             result: loud_panic_trap.result,
         }
     }

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::assertions_on_constants)]
+
 #[macro_use]
 extern crate cucumber_rust;
 
@@ -33,7 +35,7 @@ mod basic {
         };
 
         when "another thing" |_world, _step| {
-            assert!(false);
+            panic!();
         };
 
         when "something goes right" |_world, _step| { 


### PR DESCRIPTION
Since Clippy is often broken on Rust nightly for a while, we allow CI failures for nightly. I also did just suppress Clippy's lints in three places as a "fix" didn't seem helpful.  