### PR TITLE
Switch to the current Rust edition 2018.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 repository = "https://github.com/bbqsrc/cucumber-rust"
 documentation = "https://docs.rs/cucumber_rust"
 homepage = "https://github.com/bbqsrc/cucumber-rust"
+edition = "2018"
 build = "build.rs"
 
 [badges]

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-extern crate rustc_version;
-
 use rustc_version::{version_meta, Channel};
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,9 @@
 
 #![cfg_attr(feature = "nightly", feature(set_stdio))]
 
-extern crate clap;
 pub extern crate gherkin_rust as gherkin;
 pub extern crate globwalk;
-extern crate pathdiff;
 pub extern crate regex;
-extern crate termcolor;
-extern crate textwrap;
 
 use std::collections::HashMap;
 use std::fs::File;

--- a/src/output/default.rs
+++ b/src/output/default.rs
@@ -1,15 +1,16 @@
-use gherkin;
-use pathdiff::diff_paths;
 use std;
 use std::collections::HashMap;
 use std::env;
 use std::io::Write;
 use std::path::Path;
+
+use gherkin;
+use pathdiff::diff_paths;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 use textwrap;
-use TestResult;
 
-use OutputVisitor;
+use crate::OutputVisitor;
+use crate::TestResult;
 
 enum ScenarioResult {
     Pass,

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -3,7 +3,8 @@ pub mod default;
 use std::path::Path;
 
 use gherkin;
-use TestResult;
+
+use crate::TestResult;
 
 pub trait OutputVisitor: Default {
     fn visit_start(&mut self);

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,15 +1,12 @@
 #![allow(clippy::assertions_on_constants)]
 
-#[macro_use]
-extern crate cucumber_rust;
-
-use std::default::Default;
+use cucumber_rust::{after, before, cucumber, World};
 
 pub struct MyWorld {
     pub thing: bool,
 }
 
-impl cucumber_rust::World for MyWorld {}
+impl World for MyWorld {}
 
 impl Default for MyWorld {
     fn default() -> MyWorld {
@@ -19,7 +16,9 @@ impl Default for MyWorld {
 
 #[cfg(test)]
 mod basic {
-    steps!(::MyWorld => {
+    use cucumber_rust::steps;
+
+    steps!(crate::MyWorld => {
         when regex "thing (\\d+) does (.+)" (usize, String) |_world, _sz, _txt, _step| {
 
         };
@@ -70,7 +69,7 @@ fn setup() {}
 
 cucumber! {
     features: "./features",
-    world: ::MyWorld,
+    world: crate::MyWorld,
     steps: &[
         basic::steps
     ],


### PR DESCRIPTION
Note that this has no implications for users of this crate as they can continue to use whatever Rust edition they prefer.