### PR TITLE
ANSI colors based on term environment

### DIFF
--- a/src/output/default.rs
+++ b/src/output/default.rs
@@ -34,7 +34,7 @@ pub struct DefaultOutput {
 impl Default for DefaultOutput {
     fn default() -> DefaultOutput {
         DefaultOutput {
-            stdout: StandardStream::stdout(ColorChoice::Always),
+            stdout: StandardStream::stdout(ColorChoice::Auto),
             cur_feature: "".to_string(),
             feature_count: 0,
             feature_error_count: 0,


### PR DESCRIPTION
When cucumber is processed by an editor, the ANSI escape sequences are
added. This commit  lets the termcolor crate decide  whether to enable
colors based on the environment.