### PR TITLE
Change test async method to take '&mut self' instead of '&self'

### DIFF
--- a/tests/cucumber_builder.rs
+++ b/tests/cucumber_builder.rs
@@ -8,7 +8,7 @@ pub struct MyWorld {
 }
 
 impl MyWorld {
-    async fn test_async_fn(&self) -> Option<usize> {
+    async fn test_async_fn(&mut self) -> Option<usize> {
         Some(123890)
     }
 }


### PR DESCRIPTION
Shows issue with mutable reference to self being used as argument in async method.

See PR #32.