### PR TITLE
Expose event and output mods in support of user-defined event handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ pathdiff = "0.2.0"
 [[test]]
 name = "cucumber_builder"
 harness = false
+
+[[test]]
+name = "integration_test"
+harness = true

--- a/features/integration/step_variety.feature
+++ b/features/integration/step_variety.feature
@@ -1,0 +1,12 @@
+Feature: Variety of scenario outcomes get exposed for integration
+  Scenario: A successful scenario
+    When something
+    Then it's okay
+
+  Scenario: A failing scenario
+    When another thing
+    Then it's not okay
+
+  Scenario: A scenario with an unimplemented step
+    When not implemented
+    Then it's okay

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,16 +5,27 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+//! Key occurrences in the lifecycle of a Cucumber execution.
+//!
+//! The top-level enum here is `CucumberEvent`.
+//!
+//! Each event enum contains variants indicating
+//! what stage of execution Cucumber is at and,
+//! variants with detailed content about the precise
+//! sub-event
 
-use super::ExampleValues;
+pub use super::ExampleValues;
 use std::{fmt::Display, rc::Rc};
 
+/// The stringified content of stdout and stderr
+/// captured during Step execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CapturedOutput {
     pub out: String,
     pub err: String,
 }
 
+/// Panic source location information
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Location {
     pub file: String,
@@ -42,6 +53,7 @@ impl Display for Location {
     }
 }
 
+/// Panic content captured when a Step failed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PanicInfo {
     pub location: Location,
@@ -57,13 +69,16 @@ impl PanicInfo {
     }
 }
 
-pub enum TestEvent<W> {
+/// Outcome of step execution, carrying along the relevant
+/// `World` state.
+pub(crate) enum TestEvent<W> {
     Unimplemented,
     Skipped,
     Success(W, CapturedOutput),
     Failure(PanicInfo, CapturedOutput),
 }
 
+/// Event specific to a particular [Step](https://cucumber.io/docs/gherkin/reference/#step)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StepEvent {
     Unimplemented,
@@ -72,6 +87,7 @@ pub enum StepEvent {
     Failed(CapturedOutput, PanicInfo),
 }
 
+/// Event specific to a particular [Scenario](https://cucumber.io/docs/gherkin/reference/#example)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScenarioEvent {
     Starting(ExampleValues),
@@ -82,6 +98,7 @@ pub enum ScenarioEvent {
     Failed,
 }
 
+/// Event specific to a particular [Rule](https://cucumber.io/docs/gherkin/reference/#rule)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuleEvent {
     Starting,
@@ -91,6 +108,7 @@ pub enum RuleEvent {
     Failed,
 }
 
+/// Event specific to a particular [Feature](https://cucumber.io/docs/gherkin/reference/#feature)
 #[derive(Debug, Clone)]
 pub enum FeatureEvent {
     Starting,
@@ -99,6 +117,7 @@ pub enum FeatureEvent {
     Finished,
 }
 
+/// Top-level cucumber run event.
 #[derive(Debug, Clone)]
 pub enum CucumberEvent {
     Starting,

--- a/src/examples.rs
+++ b/src/examples.rs
@@ -1,7 +1,9 @@
+/// Content derived from a gherkin `Examples` table. Contains the table's keys
+/// and for values drawn from a single row.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExampleValues {
-    keys: Vec<String>,
-    values: Vec<String>,
+    pub keys: Vec<String>,
+    pub values: Vec<String>,
 }
 
 impl ExampleValues {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! A library implementing the Cucumber testing framework for Rust, in Rust.
+
 #![recursion_limit = "512"]
 #![deny(rust_2018_idioms)]
 
@@ -40,6 +42,8 @@ macro_rules! skip {
     };
 }
 
+/// The `World` trait represents shared user-defined state
+/// for a cucumber run.
 #[async_trait(?Send)]
 pub trait World: Sized + UnwindSafe + 'static {
     type Error: std::error::Error;
@@ -47,6 +51,12 @@ pub trait World: Sized + UnwindSafe + 'static {
     async fn new() -> Result<Self, Self::Error>;
 }
 
+/// During test runs, a `Cucumber` instance notifies its
+/// associated `EventHandler` implementation about the
+/// key occurrences in the test lifecycle.
+///
+/// User can replace the default `EventHandler` for a `Cucumber`
+/// at construction time using `Cucumber::with_handler`.
 pub trait EventHandler: 'static {
     fn handle_event(&mut self, event: event::CucumberEvent);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,9 @@ mod macros;
 
 mod collection;
 mod cucumber;
-mod event;
+pub mod event;
 mod examples;
-mod output;
+pub mod output;
 mod regex;
 mod runner;
 mod steps;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,78 @@
+use cucumber_rust::{Cucumber, World, EventHandler, event::*, Steps};
+use std::sync::{Arc, Mutex};
+use async_trait::async_trait;
+
+#[derive(Default, Clone)]
+struct CustomEventHandler {
+    state: Arc<Mutex<CustomEventHandlerState>>
+}
+#[derive(Default)]
+struct CustomEventHandlerState {
+    any_rule_failures: bool,
+    any_scenario_skipped: bool,
+    any_scenario_failures: bool,
+    any_step_unimplemented: bool,
+    any_step_failures: bool,
+    any_step_success: bool,
+}
+impl EventHandler for CustomEventHandler {
+    fn handle_event(&mut self, event: CucumberEvent) {
+        let mut state = self.state.lock().unwrap();
+        match event {
+            CucumberEvent::Feature(_feature, FeatureEvent::Rule(_rule, RuleEvent::Failed)) => {
+                state.any_rule_failures = true;
+            }
+            CucumberEvent::Feature(_feature, FeatureEvent::Scenario(_scenario, ScenarioEvent::Failed)) => {
+                state.any_scenario_failures = true;
+            }
+            CucumberEvent::Feature(ref _feature, FeatureEvent::Scenario(ref _scenario, ScenarioEvent::Skipped)) => {
+                state.any_scenario_skipped = true;
+            }
+            CucumberEvent::Feature(_feature, FeatureEvent::Scenario(_scenario, ScenarioEvent::Step(_step, StepEvent::Failed(_, _)))) => {
+                state.any_step_failures = true;
+            }
+            CucumberEvent::Feature(_feature, FeatureEvent::Scenario(_scenario, ScenarioEvent::Step(_step, StepEvent::Unimplemented))) => {
+                state.any_step_unimplemented = true;
+            }
+            CucumberEvent::Feature(_feature, FeatureEvent::Scenario(_scenario, ScenarioEvent::Step(_step, StepEvent::Passed(_)))) => {
+                state.any_step_success= true;
+            }
+            _ => {}
+        }
+    }
+}
+
+#[derive(Default)]
+struct StatelessWorld;
+
+#[async_trait(?Send)]
+impl World for StatelessWorld {
+    type Error = std::convert::Infallible;
+
+    async fn new() -> Result<Self, Self::Error> {
+        Ok(StatelessWorld::default())
+    }
+}
+
+#[test]
+fn user_defined_event_handlers_are_expressible() {
+    let custom_handler = CustomEventHandler::default();
+    let mut steps = Steps::<StatelessWorld>::new();
+    steps.when("something", |world, _step| world );
+    steps.when("another thing", |world, _step| world );
+    steps.then("it's okay", |world, _step| world );
+    steps.then("it's not okay", |_world, _step| panic!("Intentionally panicking to fail the step"));
+
+    let runner = Cucumber::with_handler(custom_handler.clone())
+        .steps(steps)
+        .features(&["./features/integration"]);
+
+    futures::executor::block_on(runner.run());
+
+    let handler_state = custom_handler.state.lock().unwrap();
+    assert!(!handler_state.any_rule_failures);
+    assert!(handler_state.any_step_failures);
+    assert!(handler_state.any_step_unimplemented);
+    assert!(handler_state.any_step_success);
+    assert!(handler_state.any_scenario_skipped);
+}


### PR DESCRIPTION
## The Problem

Presently the `event` and `output` modules are fully private. This prevents users from implementing `EventHandler` because the event types are private.  The lack of access to the `BasicOutput` event handler implementation in the `output` module prevents ends users from building event handlers that both delegate to the standard default handler and their own functionality.

## Motivating Use Case:

I would like to make an event handler in order to capture failures (and skips, and unimplemented bits) in order to determine the appropriate exit code for my test program. The exit code of the test program is critical for automating detection of test failures across multiple test suites. Ideally, I would like to do this event-based failure capturing with a custom `EventHandler` implementation which also does not have to re-implement all of the pretty output printing already available. 

## Proposed Solution

As implemented here, simply make the `event` and `output` modules public.

## Alternatives

Rather than making the entire modules public, it could be possible to `pub use events::{TargetedType, OtherTargetedType}` in `lib.rs` to limit the precise types exposed.  Since pretty much every single type in those modules is essential to the API, there's likely little value in going to the trouble of calling them out individually.