### PR TITLE
Return result from run

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,11 @@ name = "integration_test"
 harness = true
 edition = "2018"
 
+[[test]]
+name = "result_from_run"
+harness = false
+edition = "2018"
+
 [dev-dependencies]
 capture-runner = { path = "tests/fixtures/capture-runner" }
 serial_test = "0.5.0"

--- a/features/failing/failing.feature
+++ b/features/failing/failing.feature
@@ -1,0 +1,7 @@
+Feature: Failing
+
+    Scenario: Step that succeeds should return an Ok
+        Given nothing
+
+    Scenario: Step that fails should return an Err
+        Given a panic

--- a/features/failing/success.feature
+++ b/features/failing/success.feature
@@ -1,0 +1,7 @@
+Feature: Success
+
+    Scenario: Step that succeeds should return an Ok
+        Given nothing
+
+    Scenario: Step that succeeds should return an Ok
+        Given nothing

--- a/src/cucumber.rs
+++ b/src/cucumber.rs
@@ -10,7 +10,7 @@ use futures::StreamExt;
 use regex::Regex;
 
 use crate::steps::Steps;
-use crate::{EventHandler, World};
+use crate::{CucumberError, EventHandler, World};
 use std::path::Path;
 use std::time::Duration;
 
@@ -142,7 +142,7 @@ impl<W: World> Cucumber<W> {
         s
     }
 
-    pub async fn run(mut self) {
+    pub async fn run(mut self) -> Result<(), CucumberError> {
         let runner = crate::runner::Runner::new(
             self.steps.steps,
             std::rc::Rc::new(self.features),
@@ -155,5 +155,7 @@ impl<W: World> Cucumber<W> {
         while let Some(event) = stream.next().await {
             self.event_handler.handle_event(event);
         }
+
+        self.event_handler.steps_result()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ mod steps;
 
 use async_trait::async_trait;
 use std::panic::UnwindSafe;
+use thiserror::Error;
 
 pub use cucumber::Cucumber;
 pub use examples::ExampleValues;
@@ -67,4 +68,10 @@ pub type PanicError = Box<(dyn Any + Send + 'static)>;
 pub enum TestError {
     TimedOut,
     PanicError(PanicError),
+}
+
+#[derive(Error, Debug)]
+pub enum CucumberError {
+    #[error("Failed scenario")]
+    FailedScenario,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ pub trait World: Sized + UnwindSafe + 'static {
 /// at construction time using `Cucumber::with_handler`.
 pub trait EventHandler: 'static {
     fn handle_event(&mut self, event: event::CucumberEvent);
+    fn steps_result(&self) -> Result<(), CucumberError>;
 }
 
 pub type PanicError = Box<(dyn Any + Send + 'static)>;

--- a/src/output/default.rs
+++ b/src/output/default.rs
@@ -10,10 +10,13 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::rc::Rc;
 
-use crate::event::{FailureKind, StepFailureKind};
 use crate::{
     event::{CucumberEvent, RuleEvent, ScenarioEvent, StepEvent},
     EventHandler,
+};
+use crate::{
+    event::{FailureKind, StepFailureKind},
+    CucumberError,
 };
 use gherkin::{Feature, Rule, Scenario, Step};
 
@@ -521,6 +524,14 @@ impl EventHandler for BasicOutput {
                     }
                 }
             },
+        }
+    }
+
+    fn steps_result(&self) -> Result<(), CucumberError> {
+        if self.steps.failed + self.steps.timed_out == 0 {
+            Ok(())
+        } else {
+            Err(CucumberError::FailedScenario)
         }
     }
 }

--- a/tests/cucumber_builder.rs
+++ b/tests/cucumber_builder.rs
@@ -103,5 +103,5 @@ fn main() {
     // You may choose any executor you like (Tokio, async-std, etc)
     // You may even have an async main, it doesn't matter. The point is that
     // Cucumber is composable. :)
-    futures::executor::block_on(runner.run());
+    futures::executor::block_on(runner.run()).unwrap();
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use cucumber_rust::{event::*, t, Cucumber, EventHandler, Steps, World};
+use cucumber_rust::{event::*, t, Cucumber, CucumberError, EventHandler, Steps, World};
 use serial_test::serial;
 use std::path::PathBuf;
 use std::process::Command;
@@ -76,6 +76,19 @@ impl EventHandler for CustomEventHandler {
                 state.any_step_success = true;
             }
             _ => {}
+        }
+    }
+
+    fn steps_result(&self) -> Result<(), CucumberError> {
+        let state = self.state.lock().unwrap();
+        if state.any_rule_failures
+            || state.any_scenario_failures
+            || state.any_step_failures
+            || state.any_step_timeouts
+        {
+            Err(CucumberError::FailedScenario)
+        } else {
+            Ok(())
         }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -133,7 +133,7 @@ fn user_defined_event_handlers_are_expressible() {
         .features(&["./features/integration"])
         .step_timeout(Duration::from_secs(1));
 
-    futures::executor::block_on(runner.run());
+    let _ = futures::executor::block_on(runner.run());
 
     let handler_state = custom_handler.state.lock().unwrap();
     assert!(!handler_state.any_rule_failures);

--- a/tests/result_from_run.rs
+++ b/tests/result_from_run.rs
@@ -1,0 +1,36 @@
+extern crate cucumber_rust as cucumber;
+use async_trait::async_trait;
+use std::convert::Infallible;
+
+pub struct MyWorld;
+
+#[async_trait(?Send)]
+impl cucumber::World for MyWorld {
+    type Error = Infallible;
+
+    async fn new() -> Result<Self, Self::Error> {
+        Ok(Self {})
+    }
+}
+
+mod example_steps {
+    use cucumber::Steps;
+
+    pub fn steps() -> Steps<crate::MyWorld> {
+        let mut builder: Steps<crate::MyWorld> = Steps::new();
+
+        builder
+            .given("nothing", |world: crate::MyWorld, _step| world)
+            .given("a panic", |_world, _step| panic!("Expected panic step"));
+
+        builder
+    }
+}
+
+fn main() {
+    let runner = cucumber::Cucumber::<MyWorld>::new()
+        .features(&["./features/failing"])
+        .steps(example_steps::steps());
+
+    futures::executor::block_on(runner.run()).unwrap_err();
+}


### PR DESCRIPTION
"Closes" #84. The API could probably be improved and I'm not even sure that's the good approach to let `Cucumber::run()` return a `Result`. But it does so!