### PR TITLE
Steps auto-wiring and proc macros (#81)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,8 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: -p cucumber_rust_codegen
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cucumber_rust"
 version = "0.7.3"
+edition = "2018"
 authors = ["Brendan Molloy <brendan@bbqsrc.net>"]
 description = "Cucumber testing framework for Rust, with async support. Fully native, no external test runners or dependencies."
 license = "MIT OR Apache-2.0"
@@ -10,9 +11,13 @@ categories = ["asynchronous", "development-tools::testing"]
 repository = "https://github.com/bbqsrc/cucumber-rust"
 documentation = "https://docs.rs/cucumber_rust"
 homepage = "https://github.com/bbqsrc/cucumber-rust"
-edition = "2018"
+
+[features]
+macros = ["cucumber_rust_codegen", "inventory"]
 
 [dependencies]
+cucumber_rust_codegen = { version = "0.1", path = "./codegen", optional = true }
+
 gherkin = { package = "gherkin_rust", version = "0.8.3" }
 
 async-stream = "0.3.0"
@@ -21,6 +26,7 @@ cute_custom_default = "2.1.0"
 futures = "0.3.5"
 futures-timer = "3.0.2"
 globwalk = "0.8.0"
+inventory = { version = "0.1", optional = true }
 regex = "1.3.9"
 shh = "1.0.1"
 thiserror = "1.0.20"
@@ -43,6 +49,9 @@ capture-runner = { path = "tests/fixtures/capture-runner" }
 serial_test = "0.5.0"
 
 [workspace]
-members = ["tests/fixtures/capture-runner"]
-default-members = ["."]
+members = ["codegen", "tests/fixtures/capture-runner"]
+default-members = [".", "codegen"]
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -140,6 +140,90 @@ You can then run your Cucumber tests by running this command:
 cargo test --test cucumber
 ```
 
+#### Auto-wiring via macros
+
+By enabling `macros` feature in `Cargo.toml`:
+```toml
+[[test]]
+name = "cucumber"
+harness = false # Allows Cucumber to print output instead of libtest
+
+[dev-dependencies]
+cucumber_rust = { version = "^0.7.0", features = ["macros"] } 
+```
+
+You could leverage some conveniences in organizing your tests code:
+```rust
+use std::{cell::RefCell, convert::Infallible};
+
+use async_trait::async_trait;
+use cucumber_rust::{given, then, when, World, WorldInit};
+
+#[derive(WorldInit)]
+pub struct MyWorld {
+    // You can use this struct for mutable context in scenarios.
+    foo: String,
+    bar: usize,
+    some_value: RefCell<u8>,
+}
+
+impl MyWorld {
+    async fn test_async_fn(&mut self) {
+        *self.some_value.borrow_mut() = 123u8;
+        self.bar = 123;
+    }
+}
+
+#[async_trait(?Send)]
+impl World for MyWorld {
+    type Error = Infallible;
+
+    async fn new() -> Result<Self, Infallible> {
+        Ok(Self {
+            foo: "wat".into(),
+            bar: 0,
+            some_value: RefCell::new(0),
+        })
+    }
+}
+
+#[given("a thing")]
+async fn a_thing(world: &mut MyWorld) {
+    world.foo = "elho".into();
+    world.test_async_fn().await;
+}
+
+#[when(regex = "something goes (.*)")]
+async fn something_goes(_: &mut MyWorld, _wrong: String) {}
+
+#[given("I am trying out Cucumber")]
+fn i_am_trying_out(world: &mut MyWorld) {
+    world.foo = "Some string".to_string();
+}
+
+#[when("I consider what I am doing")]
+fn i_consider(world: &mut MyWorld) {
+    let new_string = format!("{}.", &world.foo);
+    world.foo = new_string;
+}
+
+#[then("I am interested in ATDD")]
+fn i_am_interested(world: &mut MyWorld) {
+    assert_eq!(world.foo, "Some string.");
+}
+
+#[then(regex = r"^we can (.*) rules with regex$")]
+fn we_can_regex(_: &mut MyWorld, action: String) {
+    // `action` can be anything implementing `FromStr`.
+    assert_eq!(action, "implement");
+}
+
+fn main() {
+    let runner = MyWorld::init(&["./features"]);
+    futures::executor::block_on(runner.run());
+}
+```
+
 ### Supporting crates
 
 The full gamut of Cucumber's Gherkin language is implemented by the 

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "cucumber_rust_codegen"
+version = "0.1.0"
+edition = "2018"
+authors = [
+    "Ilya Solovyiov <ilya.solovyiov@gmail.com>",
+    "Kai Ren <tyranron@gmail.com>"
+]
+description = "Code generation for `cucumber_rust` crate."
+license = "MIT OR Apache-2.0"
+keywords = ["cucumber", "codegen", "macros"]
+categories = ["asynchronous", "development-tools::testing"]
+repository = "https://github.com/bbqsrc/cucumber-rust"
+documentation = "https://docs.rs/cucumber_rust_codegen"
+homepage = "https://github.com/bbqsrc/cucumber-rust"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+inflections = "1.1"
+itertools = "0.9"
+proc-macro2 = "1.0"
+quote = "1.0"
+regex = "1.4"
+syn = { version = "1.0", features = ["derive", "extra-traits", "full"] }
+
+[dev-dependencies]
+async-trait = "0.1.41"
+futures = "0.3"
+cucumber_rust = { path = "../", features = ["macros"] }
+tokio = { version = "0.3", features = ["macros", "rt-multi-thread", "time"] }
+
+[[test]]
+name = "example"
+path = "tests/example.rs"
+harness = false
+
+[[test]]
+name = "readme"
+path = "tests/readme.rs"
+harness = false

--- a/codegen/features/doctests.feature
+++ b/codegen/features/doctests.feature
@@ -1,0 +1,7 @@
+Feature: Doctests
+
+  Scenario: Foo
+    Given foo is 10
+
+  Scenario: Bar
+    Given foo is not bar

--- a/codegen/src/attribute.rs
+++ b/codegen/src/attribute.rs
@@ -1,0 +1,485 @@
+// Copyright (c) 2020  Brendan Molloy <brendan@bbqsrc.net>,
+//                     Ilya Solovyiov <ilya.solovyiov@gmail.com>,
+//                     Kai Ren <tyranron@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! `#[given]`, `#[when]` and `#[then]` attribute macros implementation.
+
+use std::mem;
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{
+    parse::{Parse, ParseStream},
+    spanned::Spanned as _,
+};
+
+/// Generates code of `#[given]`, `#[when]` and `#[then]` attribute macros expansion.
+pub(crate) fn step(
+    attr_name: &'static str,
+    args: TokenStream,
+    input: TokenStream,
+) -> syn::Result<TokenStream> {
+    Step::parse(attr_name, args, input).and_then(Step::expand)
+}
+
+/// Parsed state (ready for code generation) of the attribute and the function it's applied to.
+#[derive(Clone, Debug)]
+struct Step {
+    /// Name of the attribute (`given`, `when` or `then`).
+    attr_name: &'static str,
+
+    /// Argument of the attribute.
+    attr_arg: AttributeArgument,
+
+    /// Function the attribute is applied to.
+    func: syn::ItemFn,
+
+    /// Name of the function argument representing a [`gherkin::Step`][1] reference.
+    ///
+    /// [1]: cucumber_rust::gherking::Step
+    step_arg_name: Option<syn::Ident>,
+}
+
+impl Step {
+    /// Parses [`Step`] definition from the attribute macro input.
+    fn parse(
+        attr_name: &'static str,
+        attr: TokenStream,
+        body: TokenStream,
+    ) -> syn::Result<Self> {
+        let attr_arg = syn::parse2::<AttributeArgument>(attr)?;
+        let mut func = syn::parse2::<syn::ItemFn>(body)?;
+
+        let step_arg_name = {
+            let (arg_marked_as_step, _) =
+                remove_all_attrs((attr_name, "step"), &mut func);
+
+            match arg_marked_as_step.len() {
+                0 => Ok(None),
+                1 => {
+                    // Unwrapping is OK here, because
+                    // `arg_marked_as_step.len() == 1`.
+                    let (ident, _) =
+                        parse_fn_arg(arg_marked_as_step.first().unwrap())?;
+                    Ok(Some(ident.clone()))
+                }
+                _ => Err(syn::Error::new(
+                    // Unwrapping is OK here, because
+                    // `arg_marked_as_step.len() > 1`.
+                    arg_marked_as_step.get(1).unwrap().span(),
+                    "Only 1 step argument is allowed",
+                )),
+            }
+        }?
+        .or_else(|| {
+            func.sig.inputs.iter().find_map(|arg| {
+                if let Ok((ident, _)) = parse_fn_arg(arg) {
+                    if ident == "step" {
+                        return Some(ident.clone());
+                    }
+                }
+                None
+            })
+        });
+
+        Ok(Self {
+            attr_arg,
+            attr_name,
+            func,
+            step_arg_name,
+        })
+    }
+
+    /// Expands generated code of this [`Step`] definition.
+    fn expand(self) -> syn::Result<TokenStream> {
+        let is_regex = matches!(self.attr_arg, AttributeArgument::Regex(_));
+
+        let func = &self.func;
+        let func_name = &func.sig.ident;
+
+        let mut func_args = TokenStream::default();
+        let (mut addon_args, mut addon_parsing) = (None, None);
+        let mut is_step_arg_considered = false;
+        if is_regex {
+            addon_args = Some(if func.sig.asyncness.is_some() {
+                quote! { __cucumber_matches, }
+            } else {
+                quote! { __cucumber_matches: Vec<String>, }
+            });
+
+            if let Some(elem_ty) = parse_slice_from_second_arg(&func.sig) {
+                addon_parsing = Some(quote! {
+                    let __cucumber_matches = __cucumber_matches
+                        .iter()
+                        .skip(1)
+                        .enumerate()
+                        .map(|(i, s)| {
+                            s.parse::<#elem_ty>().unwrap_or_else(|e| panic!(
+                                "Failed to parse {} element '{}': {}", i, s, e,
+                            ))
+                        })
+                        .collect::<Vec<_>>();
+                });
+                func_args = quote! {
+                    __cucumber_matches.as_slice(),
+                }
+            } else {
+                #[allow(clippy::redundant_closure_for_method_calls)]
+                let (idents, parsings): (Vec<_>, Vec<_>) =
+                    itertools::process_results(
+                        func.sig
+                            .inputs
+                            .iter()
+                            .skip(1)
+                            .map(|arg| self.arg_ident_and_parse_code(arg)),
+                        |i| i.unzip(),
+                    )?;
+                is_step_arg_considered = true;
+
+                addon_parsing = Some(quote! {
+                    let mut __cucumber_iter = __cucumber_matches.iter().skip(1);
+                    #( #parsings )*
+                });
+                func_args = quote! {
+                    #( #idents, )*
+                }
+            }
+        }
+        if self.step_arg_name.is_some() && !is_step_arg_considered {
+            func_args = quote! {
+                #func_args
+                ::std::borrow::Borrow::borrow(&__cucumber_step),
+            };
+        }
+
+        let world = parse_world_from_args(&self.func.sig)?;
+        let constructor_method = self.constructor_method();
+
+        let step_matcher = self.attr_arg.literal().value();
+        let step_caller = if func.sig.asyncness.is_none() {
+            let caller_name =
+                format_ident!("__cucumber_{}_{}", self.attr_name, func_name);
+            quote! {
+                {
+                    #[automatically_derived]
+                    fn #caller_name(
+                        mut __cucumber_world: #world,
+                        #addon_args
+                        __cucumber_step: ::std::rc::Rc<::cucumber_rust::gherkin::Step>,
+                    ) -> #world {
+                        #addon_parsing
+                        #func_name(&mut __cucumber_world, #func_args);
+                        __cucumber_world
+                    }
+
+                    #caller_name
+                }
+            }
+        } else {
+            quote! {
+                ::cucumber_rust::t!(
+                    |mut __cucumber_world, #addon_args __cucumber_step| {
+                        #addon_parsing
+                        #func_name(&mut __cucumber_world, #func_args).await;
+                        __cucumber_world
+                    }
+                )
+            }
+        };
+
+        Ok(quote! {
+            #func
+
+            #[automatically_derived]
+            ::cucumber_rust::private::submit!(
+                #![crate = ::cucumber_rust::private] {
+                    <#world as ::cucumber_rust::private::WorldInventory<
+                        _, _, _, _, _, _, _, _, _, _, _, _,
+                    >>::#constructor_method(#step_matcher, #step_caller)
+                }
+            );
+        })
+    }
+
+    /// Composes name of the [`WorldInventory`] method to wire this [`Step`]
+    /// with.
+    fn constructor_method(&self) -> syn::Ident {
+        let regex = match &self.attr_arg {
+            AttributeArgument::Regex(_) => "_regex",
+            AttributeArgument::Literal(_) => "",
+        };
+        format_ident!(
+            "new_{}{}{}",
+            self.attr_name,
+            regex,
+            self.func
+                .sig
+                .asyncness
+                .as_ref()
+                .map(|_| "_async")
+                .unwrap_or_default(),
+        )
+    }
+
+    /// Returns [`syn::Ident`] and parsing code of the given function's
+    /// argument.
+    ///
+    /// Function's argument type have to implement [`FromStr`].
+    ///
+    /// [`FromStr`]: std::str::FromStr
+    fn arg_ident_and_parse_code<'a>(
+        &self,
+        arg: &'a syn::FnArg,
+    ) -> syn::Result<(&'a syn::Ident, TokenStream)> {
+        let (ident, ty) = parse_fn_arg(arg)?;
+
+        let is_step_arg =
+            self.step_arg_name.as_ref().map(|i| *i == *ident) == Some(true);
+
+        let decl = if is_step_arg {
+            quote! {
+                let #ident = ::std::borrow::Borrow::borrow(&__cucumber_step);
+            }
+        } else {
+            let ty = match ty {
+                syn::Type::Path(p) => p,
+                _ => {
+                    return Err(syn::Error::new(
+                        ty.span(),
+                        "Type path expected",
+                    ))
+                }
+            };
+
+            let not_found_err = format!("{} not found", ident);
+            let parsing_err = format!(
+                "{} can not be parsed to {}",
+                ident,
+                ty.path.segments.last().unwrap().ident
+            );
+
+            quote! {
+                let #ident = __cucumber_iter
+                    .next()
+                    .expect(#not_found_err)
+                    .parse::<#ty>()
+                    .expect(#parsing_err);
+            }
+        };
+
+        Ok((ident, decl))
+    }
+}
+
+/// Argument of the attribute macro.
+#[derive(Clone, Debug)]
+enum AttributeArgument {
+    /// `#[step("literal")]` case.
+    Literal(syn::LitStr),
+
+    /// `#[step(regex = "regex")]` case.
+    Regex(syn::LitStr),
+}
+
+impl AttributeArgument {
+    /// Returns the underlying [`syn::LitStr`].
+    fn literal(&self) -> &syn::LitStr {
+        match self {
+            Self::Regex(l) | Self::Literal(l) => l,
+        }
+    }
+}
+
+impl Parse for AttributeArgument {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let arg = input.parse::<syn::NestedMeta>()?;
+        match arg {
+            syn::NestedMeta::Meta(syn::Meta::NameValue(arg)) => {
+                if arg.path.is_ident("regex") {
+                    let str_lit = to_string_literal(arg.lit)?;
+
+                    let _ = regex::Regex::new(str_lit.value().as_str())
+                        .map_err(|e| {
+                            syn::Error::new(
+                                str_lit.span(),
+                                format!("Invalid regex: {}", e.to_string()),
+                            )
+                        })?;
+
+                    Ok(AttributeArgument::Regex(str_lit))
+                } else {
+                    Err(syn::Error::new(arg.span(), "Expected regex argument"))
+                }
+            }
+
+            syn::NestedMeta::Lit(l) => {
+                Ok(AttributeArgument::Literal(to_string_literal(l)?))
+            }
+
+            syn::NestedMeta::Meta(_) => Err(syn::Error::new(
+                arg.span(),
+                "Expected string literal or regex argument",
+            )),
+        }
+    }
+}
+
+/// Removes all `#[attr_path(attr_arg)]` attributes from the given function
+/// signature and returns these attributes along with the corresponding
+/// function's arguments.
+fn remove_all_attrs<'a>(
+    (attr_path, attr_arg): (&str, &str),
+    func: &'a mut syn::ItemFn,
+) -> (Vec<&'a syn::FnArg>, Vec<syn::Attribute>) {
+    func.sig
+        .inputs
+        .iter_mut()
+        .filter_map(|arg| {
+            if let Some(attr) = remove_attr((attr_path, attr_arg), arg) {
+                return Some((&*arg, attr));
+            }
+            None
+        })
+        .unzip()
+}
+
+/// Removes attribute `#[attr_path(attr_arg)]` from function's argument, if any.
+fn remove_attr(
+    (attr_path, attr_arg): (&str, &str),
+    arg: &mut syn::FnArg,
+) -> Option<syn::Attribute> {
+    use itertools::{Either, Itertools as _};
+
+    if let syn::FnArg::Typed(typed_arg) = arg {
+        let attrs = mem::take(&mut typed_arg.attrs);
+
+        let (mut other, mut removed): (Vec<_>, Vec<_>) =
+            attrs.into_iter().partition_map(|attr| {
+                if eq_path_and_arg((attr_path, attr_arg), &attr) {
+                    Either::Right(attr)
+                } else {
+                    Either::Left(attr)
+                }
+            });
+
+        if removed.len() == 1 {
+            typed_arg.attrs = other;
+            // Unwrapping is OK here, because `step_idents.len() == 1`.
+            return Some(removed.pop().unwrap());
+        } else {
+            other.append(&mut removed);
+            typed_arg.attrs = other;
+        }
+    }
+    None
+}
+
+/// Compares attribute's path and argument.
+fn eq_path_and_arg(
+    (attr_path, attr_arg): (&str, &str),
+    attr: &syn::Attribute,
+) -> bool {
+    if let Ok(meta) = attr.parse_meta() {
+        if let syn::Meta::List(meta_list) = meta {
+            if meta_list.path.is_ident(attr_path) && meta_list.nested.len() == 1
+            {
+                // Unwrapping is OK here, because `meta_list.nested.len() == 1`.
+                if let syn::NestedMeta::Meta(m) =
+                    meta_list.nested.first().unwrap()
+                {
+                    return m.path().is_ident(attr_arg);
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Parses [`syn::Ident`] and [`syn::Type`] from the given [`syn::FnArg`].
+fn parse_fn_arg(arg: &syn::FnArg) -> syn::Result<(&syn::Ident, &syn::Type)> {
+    let arg = match arg {
+        syn::FnArg::Typed(t) => t,
+        _ => {
+            return Err(syn::Error::new(
+                arg.span(),
+                "Expected regular argument, found `self`",
+            ))
+        }
+    };
+
+    let ident = match arg.pat.as_ref() {
+        syn::Pat::Ident(i) => &i.ident,
+        _ => return Err(syn::Error::new(arg.span(), "Expected ident")),
+    };
+
+    Ok((ident, arg.ty.as_ref()))
+}
+
+/// Parses type of a slice element from a second argument of the given function
+/// signature.
+fn parse_slice_from_second_arg(sig: &syn::Signature) -> Option<&syn::TypePath> {
+    sig.inputs
+        .iter()
+        .nth(1)
+        .and_then(|second_arg| match second_arg {
+            syn::FnArg::Typed(typed_arg) => Some(typed_arg),
+            _ => None,
+        })
+        .and_then(|typed_arg| match typed_arg.ty.as_ref() {
+            syn::Type::Reference(r) => Some(r),
+            _ => None,
+        })
+        .and_then(|ty_ref| match ty_ref.elem.as_ref() {
+            syn::Type::Slice(s) => Some(s),
+            _ => None,
+        })
+        .and_then(|slice| match slice.elem.as_ref() {
+            syn::Type::Path(ty) => Some(ty),
+            _ => None,
+        })
+}
+
+/// Parses [`cucumber::World`] from arguments of the function signature.
+///
+/// [`cucumber::World`]: cucumber_rust::World
+fn parse_world_from_args(sig: &syn::Signature) -> syn::Result<&syn::TypePath> {
+    sig.inputs
+        .first()
+        .ok_or_else(|| sig.ident.span())
+        .and_then(|first_arg| match first_arg {
+            syn::FnArg::Typed(a) => Ok(a),
+            _ => Err(first_arg.span()),
+        })
+        .and_then(|typed_arg| match typed_arg.ty.as_ref() {
+            syn::Type::Reference(r) => Ok(r),
+            _ => Err(typed_arg.span()),
+        })
+        .and_then(|world_ref| match world_ref.mutability {
+            Some(_) => Ok(world_ref),
+            None => Err(world_ref.span()),
+        })
+        .and_then(|world_mut_ref| match world_mut_ref.elem.as_ref() {
+            syn::Type::Path(p) => Ok(p),
+            _ => Err(world_mut_ref.span()),
+        })
+        .map_err(|span| {
+            syn::Error::new(
+                span,
+                "First function argument expected to be `&mut World`",
+            )
+        })
+}
+
+/// Converts [`syn::Lit`] to [`syn::LitStr`] if possible.
+fn to_string_literal(l: syn::Lit) -> syn::Result<syn::LitStr> {
+    match l {
+        syn::Lit::Str(str) => Ok(str),
+        _ => Err(syn::Error::new(l.span(), "Expected string literal")),
+    }
+}

--- a/codegen/src/derive.rs
+++ b/codegen/src/derive.rs
@@ -1,0 +1,117 @@
+// Copyright (c) 2020  Brendan Molloy <brendan@bbqsrc.net>,
+//                     Ilya Solovyiov <ilya.solovyiov@gmail.com>,
+//                     Kai Ren <tyranron@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! `#[derive(WorldInit)]` macro implementation.
+
+use inflections::case::to_pascal_case;
+use proc_macro2::{Span, TokenStream};
+use quote::{format_ident, quote};
+
+/// Generates code of `#[derive(WorldInit)]` macro expansion.
+pub(crate) fn world_init(
+    input: TokenStream,
+    steps: &[&str],
+) -> syn::Result<TokenStream> {
+    let input = syn::parse2::<syn::DeriveInput>(input)?;
+
+    let step_types = step_types(steps);
+    let step_structs = generate_step_structs(steps, &input);
+
+    let world = &input.ident;
+
+    Ok(quote! {
+        impl ::cucumber_rust::private::WorldInventory<
+            #( #step_types, )*
+        > for #world {}
+
+        #( #step_structs )*
+    })
+}
+
+/// Generates [`syn::Ident`]s of generic types for private trait impl.
+fn step_types(steps: &[&str]) -> Vec<syn::Ident> {
+    steps
+        .iter()
+        .flat_map(|step| {
+            let step = to_pascal_case(step);
+            vec![
+                format_ident!("Cucumber{}", step),
+                format_ident!("Cucumber{}Regex", step),
+                format_ident!("Cucumber{}Async", step),
+                format_ident!("Cucumber{}RegexAsync", step),
+            ]
+        })
+        .collect()
+}
+
+/// Generates structs and their implementations of private traits.
+fn generate_step_structs(
+    steps: &[&str],
+    world: &syn::DeriveInput,
+) -> Vec<TokenStream> {
+    let (world, world_vis) = (&world.ident, &world.vis);
+
+    let idents = [
+        (
+            syn::Ident::new("Step", Span::call_site()),
+            syn::Ident::new("CucumberFn", Span::call_site()),
+        ),
+        (
+            syn::Ident::new("StepRegex", Span::call_site()),
+            syn::Ident::new("CucumberRegexFn", Span::call_site()),
+        ),
+        (
+            syn::Ident::new("StepAsync", Span::call_site()),
+            syn::Ident::new("CucumberAsyncFn", Span::call_site()),
+        ),
+        (
+            syn::Ident::new("StepRegexAsync", Span::call_site()),
+            syn::Ident::new("CucumberAsyncRegexFn", Span::call_site()),
+        ),
+    ];
+
+    step_types(steps)
+        .iter()
+        .zip(idents.iter().cycle())
+        .map(|(ty, (trait_ty, func))| {
+            quote! {
+                #[automatically_derived]
+                #[doc(hidden)]
+                #world_vis struct #ty {
+                    #[doc(hidden)]
+                    pub name: &'static str,
+
+                    #[doc(hidden)]
+                    pub func: ::cucumber_rust::private::#func<#world>,
+                }
+
+                #[automatically_derived]
+                impl ::cucumber_rust::private::#trait_ty<#world> for #ty {
+                    fn new (
+                        name: &'static str,
+                        func: ::cucumber_rust::private::#func<#world>,
+                    ) -> Self {
+                        Self { name, func }
+                    }
+
+                    fn inner(&self) -> (
+                        &'static str,
+                        ::cucumber_rust::private::#func<#world>,
+                    ) {
+                        (self.name, self.func.clone())
+                    }
+                }
+
+                #[automatically_derived]
+                ::cucumber_rust::private::collect!(#ty);
+            }
+        })
+        .collect()
+}

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,0 +1,152 @@
+// Copyright (c) 2020  Brendan Molloy <brendan@bbqsrc.net>,
+//                     Ilya Solovyiov <ilya.solovyiov@gmail.com>,
+//                     Kai Ren <tyranron@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Code generation for [`cucumber_rust`] tests auto-wiring.
+
+#![deny(
+    missing_debug_implementations,
+    nonstandard_style,
+    rust_2018_idioms,
+    trivial_casts,
+    trivial_numeric_casts
+)]
+#![warn(
+    deprecated_in_future,
+    missing_copy_implementations,
+    missing_docs,
+    unreachable_pub,
+    unused_import_braces,
+    unused_labels,
+    unused_qualifications,
+    unused_results
+)]
+
+mod attribute;
+mod derive;
+
+use proc_macro::TokenStream;
+
+macro_rules! step_attribute {
+    ($name:ident) => {
+        /// Attribute to auto-wire the test to the [`World`] implementer.
+        ///
+        /// There are 3 step-specific attributes:
+        /// - [`given`]
+        /// - [`when`]
+        /// - [`then`]
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use std::{convert::Infallible, rc::Rc};
+        /// #
+        /// # use async_trait::async_trait;
+        /// use cucumber_rust::{given, World, WorldInit};
+        ///
+        /// #[derive(WorldInit)]
+        /// struct MyWorld;
+        ///
+        /// #[async_trait(?Send)]
+        /// impl World for MyWorld {
+        ///     type Error = Infallible;
+        ///
+        ///     async fn new() -> Result<Self, Self::Error> {
+        ///         Ok(Self {})
+        ///     }
+        /// }
+        ///
+        /// #[given(regex = r"(\S+) is (\d+)")]
+        /// fn test(w: &mut MyWorld, param: String, num: i32) {
+        ///     assert_eq!(param, "foo");
+        ///     assert_eq!(num, 0);
+        /// }
+        ///
+        /// #[tokio::main]
+        /// async fn main() {
+        ///     let runner = MyWorld::init(&["./features"]);
+        ///     runner.run().await;
+        /// }
+        /// ```
+        ///
+        /// # Arguments
+        ///
+        /// - First argument has to be mutable refence to the [`WorldInit`] deriver (your [`World`]
+        ///   implementer).
+        /// - Other argument's types have to implement [`FromStr`] or it has to be a slice where the
+        ///   element type also implements [`FromStr`].
+        /// - To use [`gherking::Step`], name the argument as `step`, **or** mark the argument with
+        ///   a `#[given(step)]` attribute.
+        ///
+        /// ```
+        /// # use std::convert::Infallible;
+        /// # use std::rc::Rc;
+        /// #
+        /// # use async_trait::async_trait;
+        /// # use cucumber_rust::{gherkin::Step, given, World, WorldInit};
+        /// #
+        /// #[derive(WorldInit)]
+        /// struct MyWorld;
+        /// #
+        /// # #[async_trait(?Send)]
+        /// # impl World for MyWorld {
+        /// #     type Error = Infallible;
+        /// #
+        /// #     async fn new() -> Result<Self, Self::Error> {
+        /// #         Ok(Self {})
+        /// #     }
+        /// # }
+        ///
+        /// #[given(regex = r"(\S+) is not (\S+)")]
+        /// fn test_step(
+        ///     w: &mut MyWorld,
+        ///     matches: &[String],
+        ///     #[given(step)] s: &Step,
+        /// ) {
+        ///     assert_eq!(matches.get(0).unwrap(), "foo");
+        ///     assert_eq!(matches.get(1).unwrap(), "bar");
+        ///     assert_eq!(s.value, "foo is bar");
+        /// }
+        /// #
+        /// # #[tokio::main]
+        /// # async fn main() {
+        /// #     let runner = MyWorld::init(&["./features"]);
+        /// #     runner.run().await;
+        /// # }
+        /// ```
+        ///
+        /// [`FromStr`]: std::str::FromStr
+        /// [`gherking::Step`]: cucumber_rust::gherking::Step
+        /// [`World`]: cucumber_rust::World
+        #[proc_macro_attribute]
+        pub fn $name(args: TokenStream, input: TokenStream) -> TokenStream {
+            attribute::step(std::stringify!($name), args.into(), input.into())
+                .unwrap_or_else(|e| e.to_compile_error())
+                .into()
+        }
+    };
+}
+
+macro_rules! steps {
+    ($($name:ident),*) => {
+        /// Derive macro for tests auto-wiring.
+        ///
+        /// See [`given`], [`when`] and [`then`] attributes for further details.
+        #[proc_macro_derive(WorldInit)]
+        pub fn derive_init(input: TokenStream) -> TokenStream {
+            derive::world_init(input.into(), &[$(std::stringify!($name)),*])
+                .unwrap_or_else(|e| e.to_compile_error())
+                .into()
+        }
+
+        $(step_attribute!($name);)*
+    }
+}
+
+steps!(given, when, then);

--- a/codegen/tests/example.rs
+++ b/codegen/tests/example.rs
@@ -1,0 +1,45 @@
+use std::{convert::Infallible, time::Duration};
+
+use async_trait::async_trait;
+use cucumber_rust::{gherkin::Step, given, World, WorldInit};
+use tokio::time;
+
+#[derive(WorldInit)]
+pub struct MyWorld {
+    pub foo: i32,
+}
+
+#[async_trait(?Send)]
+impl World for MyWorld {
+    type Error = Infallible;
+
+    async fn new() -> Result<Self, Self::Error> {
+        Ok(Self { foo: 0 })
+    }
+}
+
+#[given(regex = r"(\S+) is (\d+)")]
+async fn test_regex_async(w: &mut MyWorld, step: String, #[given(step)] s: &Step, num: usize) {
+    time::sleep(Duration::new(1, 0)).await;
+
+    assert_eq!(step, "foo");
+    assert_eq!(num, 0);
+    assert_eq!(s.value, "foo is 0");
+
+    w.foo += 1;
+}
+
+#[given(regex = r"(\S+) is sync (\d+)")]
+async fn test_regex_sync(w: &mut MyWorld, s: String, step: &Step, num: usize) {
+    assert_eq!(s, "foo");
+    assert_eq!(num, 0);
+    assert_eq!(step.value, "foo is sync 0");
+
+    w.foo += 1;
+}
+
+#[tokio::main]
+async fn main() {
+    let runner = MyWorld::init(&["./tests/features"]);
+    runner.run().await;
+}

--- a/codegen/tests/features/example.feature
+++ b/codegen/tests/features/example.feature
@@ -1,0 +1,7 @@
+Feature: Example feature
+
+  Scenario: An example scenario
+    Given foo is 0
+
+  Scenario: An example sync scenario
+    Given foo is sync 0

--- a/codegen/tests/readme.rs
+++ b/codegen/tests/readme.rs
@@ -1,0 +1,68 @@
+use std::{cell::RefCell, convert::Infallible};
+
+use async_trait::async_trait;
+use cucumber_rust::{given, then, when, World, WorldInit};
+
+#[derive(WorldInit)]
+pub struct MyWorld {
+    // You can use this struct for mutable context in scenarios.
+    foo: String,
+    bar: usize,
+    some_value: RefCell<u8>,
+}
+
+impl MyWorld {
+    async fn test_async_fn(&mut self) {
+        *self.some_value.borrow_mut() = 123u8;
+        self.bar = 123;
+    }
+}
+
+#[async_trait(?Send)]
+impl World for MyWorld {
+    type Error = Infallible;
+
+    async fn new() -> Result<Self, Infallible> {
+        Ok(Self {
+            foo: "wat".into(),
+            bar: 0,
+            some_value: RefCell::new(0),
+        })
+    }
+}
+
+#[given("a thing")]
+async fn a_thing(world: &mut MyWorld) {
+    world.foo = "elho".into();
+    world.test_async_fn().await;
+}
+
+#[when(regex = "something goes (.*)")]
+async fn something_goes(_: &mut MyWorld, _wrong: String) {}
+
+#[given("I am trying out Cucumber")]
+fn i_am_trying_out(world: &mut MyWorld) {
+    world.foo = "Some string".to_string();
+}
+
+#[when("I consider what I am doing")]
+fn i_consider(world: &mut MyWorld) {
+    let new_string = format!("{}.", &world.foo);
+    world.foo = new_string;
+}
+
+#[then("I am interested in ATDD")]
+fn i_am_interested(world: &mut MyWorld) {
+    assert_eq!(world.foo, "Some string.");
+}
+
+#[then(regex = r"^we can (.*) rules with regex$")]
+fn we_can_regex(_: &mut MyWorld, action: String) {
+    // `action` can be anything implementing `FromStr`.
+    assert_eq!(action, "implement");
+}
+
+fn main() {
+    let runner = MyWorld::init(&["./features"]);
+    futures::executor::block_on(runner.run());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 
 #![recursion_limit = "512"]
 #![deny(rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Re-export Gherkin for the convenience of everybody
 pub use gherkin;
@@ -24,8 +25,12 @@ pub mod event;
 mod examples;
 pub mod output;
 mod regex;
-mod runner;
+pub(crate) mod runner;
 mod steps;
+
+#[cfg(feature = "macros")]
+#[doc(hidden)]
+pub mod private;
 
 use async_trait::async_trait;
 use std::panic::UnwindSafe;
@@ -34,6 +39,18 @@ pub use cucumber::Cucumber;
 pub use examples::ExampleValues;
 use std::any::Any;
 pub use steps::Steps;
+
+#[cfg(feature = "macros")]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+#[doc(inline)]
+pub use self::private::WorldInit;
+#[cfg(feature = "macros")]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+#[doc(inline)]
+pub use cucumber_rust_codegen::{given, then, when, WorldInit};
+#[cfg(feature = "macros")]
+#[doc(hidden)]
+pub use futures;
 
 const TEST_SKIPPED: &str = "Cucumber: test skipped";
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,7 +37,7 @@ macro_rules! t {
     // Async with block and mutable world
     (| mut $world:ident, $step:ident | $($input:tt)*) => {
         std::rc::Rc::new(|mut $world, $step| {
-            use futures::future::FutureExt;
+            use $crate::futures::future::FutureExt as _;
             std::panic::AssertUnwindSafe(async move { $($input)* })
                 .catch_unwind()
                 .map(|r| r.map_err($crate::TestError::PanicError))
@@ -47,7 +47,7 @@ macro_rules! t {
     // Async with block and immutable world
     (| $world:ident, $step:ident | $($input:tt)*) => {
         std::rc::Rc::new(|$world, $step| {
-            use futures::future::FutureExt;
+            use $crate::futures::future::FutureExt as _;
             std::panic::AssertUnwindSafe(async move { $($input)* })
                 .catch_unwind()
                 .map(|r| r.map_err($crate::TestError::PanicError))
@@ -57,7 +57,7 @@ macro_rules! t {
     // Async regex with block and mutable world
     (| mut $world:ident, $matches:ident, $step:ident | $($input:tt)*) => {
         std::rc::Rc::new(|mut $world, $matches, $step| {
-            use futures::future::FutureExt;
+            use $crate::futures::future::FutureExt as _;
             std::panic::AssertUnwindSafe(async move { $($input)* })
                 .catch_unwind()
                 .map(|r| r.map_err($crate::TestError::PanicError))
@@ -67,7 +67,7 @@ macro_rules! t {
     // Async regex with block and immutable world
     (| $world:ident, $matches:ident, $step:ident | $($input:tt)*) => {
         std::rc::Rc::new(|$world, $matches, $step| {
-            use futures::future::FutureExt;
+            use $crate::futures::future::FutureExt as _;
             std::panic::AssertUnwindSafe(async move { $($input)* })
                 .catch_unwind()
                 .map(|r| r.map_err($crate::TestError::PanicError))

--- a/src/private.rs
+++ b/src/private.rs
@@ -1,0 +1,248 @@
+// Copyright (c) 2018-2020  Brendan Molloy <brendan@bbqsrc.net>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Helper type-level glue for [`cucumber_rust_codegen`] crate.
+
+use std::{panic::UnwindSafe, rc::Rc};
+
+pub use inventory::{self, collect, submit};
+
+use crate::{runner::TestFuture, Cucumber, Steps, World};
+
+/// [`World`] extension with auto-wiring capabilities.
+pub trait WorldInit<G1, G2, G3, G4, W1, W2, W3, W4, T1, T2, T3, T4>:
+    WorldInventory<G1, G2, G3, G4, W1, W2, W3, W4, T1, T2, T3, T4>
+where
+    G1: Step<Self> + inventory::Collect,
+    G2: StepRegex<Self> + inventory::Collect,
+    G3: StepAsync<Self> + inventory::Collect,
+    G4: StepRegexAsync<Self> + inventory::Collect,
+    W1: Step<Self> + inventory::Collect,
+    W2: StepRegex<Self> + inventory::Collect,
+    W3: StepAsync<Self> + inventory::Collect,
+    W4: StepRegexAsync<Self> + inventory::Collect,
+    T1: Step<Self> + inventory::Collect,
+    T2: StepRegex<Self> + inventory::Collect,
+    T3: StepAsync<Self> + inventory::Collect,
+    T4: StepRegexAsync<Self> + inventory::Collect,
+{
+    /// Returns runner for tests with auto-wired steps marked by [`given`], [`when`] and [`then`]
+    /// attributes.
+    ///
+    /// [`given`]: crate::given
+    /// [`then`]: crate::then
+    /// [`when`]: crate::when
+    #[must_use]
+    fn init(features: &[&str]) -> Cucumber<Self> {
+        Cucumber::new().features(features).steps({
+            let mut builder: Steps<Self> = Steps::new();
+
+            let (simple, regex, async_, async_regex) = Self::cucumber_given();
+            for e in simple {
+                let _ = builder.given(e.inner().0, e.inner().1);
+            }
+            for e in regex {
+                let _ = builder.given_regex(e.inner().0, e.inner().1);
+            }
+            for e in async_ {
+                let _ = builder.given_async(e.inner().0, e.inner().1.clone());
+            }
+            for e in async_regex {
+                let _ = builder.given_regex_async(e.inner().0, e.inner().1.clone());
+            }
+
+            let (simple, regex, async_, async_regex) = Self::cucumber_when();
+            for e in simple {
+                let _ = builder.when(e.inner().0, e.inner().1);
+            }
+            for e in regex {
+                let _ = builder.when_regex(e.inner().0, e.inner().1);
+            }
+            for e in async_ {
+                let _ = builder.when_async(e.inner().0, e.inner().1.clone());
+            }
+            for e in async_regex {
+                let _ = builder.when_regex_async(e.inner().0, e.inner().1.clone());
+            }
+
+            let (simple, regex, async_, async_regex) = Self::cucumber_then();
+            for e in simple {
+                let _ = builder.then(e.inner().0, e.inner().1);
+            }
+            for e in regex {
+                let _ = builder.then_regex(e.inner().0, e.inner().1);
+            }
+            for e in async_ {
+                let _ = builder.then_async(e.inner().0, e.inner().1.clone());
+            }
+            for e in async_regex {
+                let _ = builder.then_regex_async(e.inner().0, e.inner().1.clone());
+            }
+
+            builder
+        })
+    }
+}
+
+impl<G1, G2, G3, G4, W1, W2, W3, W4, T1, T2, T3, T4, E>
+    WorldInit<G1, G2, G3, G4, W1, W2, W3, W4, T1, T2, T3, T4> for E
+where
+    G1: Step<Self> + inventory::Collect,
+    G2: StepRegex<Self> + inventory::Collect,
+    G3: StepAsync<Self> + inventory::Collect,
+    G4: StepRegexAsync<Self> + inventory::Collect,
+    W1: Step<Self> + inventory::Collect,
+    W2: StepRegex<Self> + inventory::Collect,
+    W3: StepAsync<Self> + inventory::Collect,
+    W4: StepRegexAsync<Self> + inventory::Collect,
+    T1: Step<Self> + inventory::Collect,
+    T2: StepRegex<Self> + inventory::Collect,
+    T3: StepAsync<Self> + inventory::Collect,
+    T4: StepRegexAsync<Self> + inventory::Collect,
+    E: WorldInventory<G1, G2, G3, G4, W1, W2, W3, W4, T1, T2, T3, T4>,
+{
+}
+
+/// [`World`] extension allowing to register steps in [`inventory`].
+pub trait WorldInventory<G1, G2, G3, G4, W1, W2, W3, W4, T1, T2, T3, T4>: World
+where
+    G1: Step<Self> + inventory::Collect,
+    G2: StepRegex<Self> + inventory::Collect,
+    G3: StepAsync<Self> + inventory::Collect,
+    G4: StepRegexAsync<Self> + inventory::Collect,
+    W1: Step<Self> + inventory::Collect,
+    W2: StepRegex<Self> + inventory::Collect,
+    W3: StepAsync<Self> + inventory::Collect,
+    W4: StepRegexAsync<Self> + inventory::Collect,
+    T1: Step<Self> + inventory::Collect,
+    T2: StepRegex<Self> + inventory::Collect,
+    T3: StepAsync<Self> + inventory::Collect,
+    T4: StepRegexAsync<Self> + inventory::Collect,
+{
+    #[must_use]
+    fn cucumber_given() -> (
+        inventory::iter<G1>,
+        inventory::iter<G2>,
+        inventory::iter<G3>,
+        inventory::iter<G4>,
+    ) {
+        (
+            inventory::iter,
+            inventory::iter,
+            inventory::iter,
+            inventory::iter,
+        )
+    }
+
+    fn new_given(name: &'static str, fun: CucumberFn<Self>) -> G1 {
+        G1::new(name, fun)
+    }
+
+    fn new_given_regex(name: &'static str, fun: CucumberRegexFn<Self>) -> G2 {
+        G2::new(name, fun)
+    }
+
+    fn new_given_async(name: &'static str, fun: CucumberAsyncFn<Self>) -> G3 {
+        G3::new(name, fun)
+    }
+
+    fn new_given_regex_async(name: &'static str, fun: CucumberAsyncRegexFn<Self>) -> G4 {
+        G4::new(name, fun)
+    }
+
+    #[must_use]
+    fn cucumber_when() -> (
+        inventory::iter<W1>,
+        inventory::iter<W2>,
+        inventory::iter<W3>,
+        inventory::iter<W4>,
+    ) {
+        (
+            inventory::iter,
+            inventory::iter,
+            inventory::iter,
+            inventory::iter,
+        )
+    }
+
+    fn new_when(name: &'static str, fun: CucumberFn<Self>) -> W1 {
+        W1::new(name, fun)
+    }
+
+    fn new_when_regex(name: &'static str, fun: CucumberRegexFn<Self>) -> W2 {
+        W2::new(name, fun)
+    }
+
+    fn new_when_async(name: &'static str, fun: CucumberAsyncFn<Self>) -> W3 {
+        W3::new(name, fun)
+    }
+
+    fn new_when_regex_async(name: &'static str, fun: CucumberAsyncRegexFn<Self>) -> W4 {
+        W4::new(name, fun)
+    }
+
+    #[must_use]
+    fn cucumber_then() -> (
+        inventory::iter<T1>,
+        inventory::iter<T2>,
+        inventory::iter<T3>,
+        inventory::iter<T4>,
+    ) {
+        (
+            inventory::iter,
+            inventory::iter,
+            inventory::iter,
+            inventory::iter,
+        )
+    }
+
+    fn new_then(name: &'static str, fun: CucumberFn<Self>) -> T1 {
+        T1::new(name, fun)
+    }
+
+    fn new_then_regex(name: &'static str, fun: CucumberRegexFn<Self>) -> T2 {
+        T2::new(name, fun)
+    }
+
+    fn new_then_async(name: &'static str, fun: CucumberAsyncFn<Self>) -> T3 {
+        T3::new(name, fun)
+    }
+
+    fn new_then_regex_async(name: &'static str, fun: CucumberAsyncRegexFn<Self>) -> T4 {
+        T4::new(name, fun)
+    }
+}
+
+pub trait Step<W> {
+    fn new(_: &'static str, _: CucumberFn<W>) -> Self;
+    fn inner(&self) -> (&'static str, CucumberFn<W>);
+}
+
+pub trait StepRegex<W> {
+    fn new(_: &'static str, _: CucumberRegexFn<W>) -> Self;
+    fn inner(&self) -> (&'static str, CucumberRegexFn<W>);
+}
+
+pub trait StepAsync<W> {
+    fn new(_: &'static str, _: CucumberAsyncFn<W>) -> Self;
+    fn inner(&self) -> (&'static str, CucumberAsyncFn<W>);
+}
+
+pub trait StepRegexAsync<W> {
+    fn new(_: &'static str, _: CucumberAsyncRegexFn<W>) -> Self;
+    fn inner(&self) -> (&'static str, CucumberAsyncRegexFn<W>);
+}
+
+pub type CucumberFn<W> = fn(W, Rc<gherkin::Step>) -> W;
+
+pub type CucumberRegexFn<W> = fn(W, Vec<String>, Rc<gherkin::Step>) -> W;
+
+pub type CucumberAsyncFn<W> = Rc<dyn Fn(W, Rc<gherkin::Step>) -> TestFuture<W> + UnwindSafe>;
+
+pub type CucumberAsyncRegexFn<W> =
+    Rc<dyn Fn(W, Vec<String>, Rc<gherkin::Step>) -> TestFuture<W> + UnwindSafe>;

--- a/src/steps.rs
+++ b/src/steps.rs
@@ -44,7 +44,7 @@ impl<W: World> Steps<W> {
         name: &'static str,
         test_fn: fn(W, Rc<gherkin::Step>) -> W,
     ) -> &mut Self {
-        use futures::future::FutureExt;
+        use futures::future::FutureExt as _;
 
         let test_fn = std::rc::Rc::new(move |world: W, step| {
             // let test_fn = Rc::clone(&test_fn);
@@ -75,7 +75,8 @@ impl<W: World> Steps<W> {
         name: &'static str,
         test_fn: fn(W, Vec<String>, Rc<gherkin::Step>) -> W,
     ) -> &mut Self {
-        use futures::future::FutureExt;
+        use futures::future::FutureExt as _;
+
         let regex = regex::Regex::new(name)
             .unwrap_or_else(|_| panic!("`{}` is not a valid regular expression", name));
 


### PR DESCRIPTION
Closes #81

This PR integrates the machinery described in #81 into `cucumber_rust` crate. This, however, requires to intoduce a `cucumber_rust_codegen` sub-crate.

The initial idea was fully designed and implemented by @ilslv in our closed code base, and I'm just baking his work into this upstream crate. Please, preserve the `Co-authored-by:` for him in commit message on merge.

## Checklist

- [x] Tests are added
- [x] Documentation is added
- [x] `macros` feature on <https://docs.rs> is rendered
- [x] README is updated

Filling the CHANGELOG in the correct way was left for maintainers.