### PR TITLE
Implement failure reporting

### DIFF
--- a/src/cucumber.rs
+++ b/src/cucumber.rs
@@ -154,21 +154,13 @@ impl<W: World> Cucumber<W> {
         let mut stream = runner.run();
 
         while let Some(event) = stream.next().await {
-            let ret = {
-                if let crate::event::CucumberEvent::Finished(ref result) = event {
-                    Some(result.clone())
-                } else {
-                    None
-                }
-            };
+            self.event_handler.handle_event(&event);
 
-            self.event_handler.handle_event(event);
-
-            if let Some(res) = ret {
-                return res
+            if let crate::event::CucumberEvent::Finished(result) = event {
+                return result
             }
         }
 
-        unimplemented!("Programmer Error - run _must end_ with the Finished Event")
+        panic!("Invariant broken: no Finish event found before stream ended")
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -166,17 +166,7 @@ impl FeatureEvent {
 pub enum CucumberEvent {
     Starting,
     Feature(Rc<gherkin::Feature>, FeatureEvent),
-    Finished,
-}
-
-impl CucumberEvent {
-    /// Indicates this is a failing event
-    pub fn failed(&self) -> bool {
-        match self {
-            CucumberEvent::Feature(_, ref f) => f.failed(),
-            _ => false,
-        }
-    }
+    Finished(crate::runner::RunResult),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/event.rs
+++ b/src/event.rs
@@ -87,6 +87,15 @@ pub enum StepEvent {
     Passed(CapturedOutput),
     Failed(StepFailureKind),
 }
+impl StepEvent {
+    /// Indicates this is a failing event
+    pub fn failed(&self) -> bool {
+        match self {
+            StepEvent::Failed(_) => true,
+            _ => false,
+        }
+    }
+}
 
 /// Event specific to a particular [Scenario](https://cucumber.io/docs/gherkin/reference/#example)
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -99,6 +108,18 @@ pub enum ScenarioEvent {
     Failed(FailureKind),
 }
 
+impl ScenarioEvent {
+    /// Indicates this is a failing event
+    pub fn failed(&self) -> bool {
+        match self {
+            ScenarioEvent::Failed(_) => true,
+            ScenarioEvent::Background(_, ref s) |
+                ScenarioEvent::Step(_, ref s) => s.failed(),
+            _ => false,
+        }
+    }
+}
+
 /// Event specific to a particular [Rule](https://cucumber.io/docs/gherkin/reference/#rule)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuleEvent {
@@ -107,6 +128,17 @@ pub enum RuleEvent {
     Skipped,
     Passed,
     Failed(FailureKind),
+}
+
+impl RuleEvent {
+    /// Indicates this is a failing event
+    pub fn failed(&self) -> bool {
+        match self {
+            RuleEvent::Failed(_) => true,
+            RuleEvent::Scenario(_, ref s) => s.failed(),
+            _ => false,
+        }
+    }
 }
 
 /// Event specific to a particular [Feature](https://cucumber.io/docs/gherkin/reference/#feature)
@@ -118,12 +150,33 @@ pub enum FeatureEvent {
     Finished,
 }
 
+impl FeatureEvent {
+    /// Indicates this is a failing event
+    pub fn failed(&self) -> bool {
+        match self {
+            FeatureEvent::Scenario(_, ref s) => s.failed(),
+            FeatureEvent::Rule(_, ref r) => r.failed(),
+            _ => false,
+        }
+    }
+}
+
 /// Top-level cucumber run event.
 #[derive(Debug, Clone)]
 pub enum CucumberEvent {
     Starting,
     Feature(Rc<gherkin::Feature>, FeatureEvent),
     Finished,
+}
+
+impl CucumberEvent {
+    /// Indicates this is a failing event
+    pub fn failed(&self) -> bool {
+        match self {
+            CucumberEvent::Feature(_, ref f) => f.failed(),
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/event.rs
+++ b/src/event.rs
@@ -87,15 +87,6 @@ pub enum StepEvent {
     Passed(CapturedOutput),
     Failed(StepFailureKind),
 }
-impl StepEvent {
-    /// Indicates this is a failing event
-    pub fn failed(&self) -> bool {
-        match self {
-            StepEvent::Failed(_) => true,
-            _ => false,
-        }
-    }
-}
 
 /// Event specific to a particular [Scenario](https://cucumber.io/docs/gherkin/reference/#example)
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -108,18 +99,6 @@ pub enum ScenarioEvent {
     Failed(FailureKind),
 }
 
-impl ScenarioEvent {
-    /// Indicates this is a failing event
-    pub fn failed(&self) -> bool {
-        match self {
-            ScenarioEvent::Failed(_) => true,
-            ScenarioEvent::Background(_, ref s) |
-                ScenarioEvent::Step(_, ref s) => s.failed(),
-            _ => false,
-        }
-    }
-}
-
 /// Event specific to a particular [Rule](https://cucumber.io/docs/gherkin/reference/#rule)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuleEvent {
@@ -130,17 +109,6 @@ pub enum RuleEvent {
     Failed(FailureKind),
 }
 
-impl RuleEvent {
-    /// Indicates this is a failing event
-    pub fn failed(&self) -> bool {
-        match self {
-            RuleEvent::Failed(_) => true,
-            RuleEvent::Scenario(_, ref s) => s.failed(),
-            _ => false,
-        }
-    }
-}
-
 /// Event specific to a particular [Feature](https://cucumber.io/docs/gherkin/reference/#feature)
 #[derive(Debug, Clone)]
 pub enum FeatureEvent {
@@ -148,17 +116,6 @@ pub enum FeatureEvent {
     Scenario(Rc<gherkin::Scenario>, ScenarioEvent),
     Rule(Rc<gherkin::Rule>, RuleEvent),
     Finished,
-}
-
-impl FeatureEvent {
-    /// Indicates this is a failing event
-    pub fn failed(&self) -> bool {
-        match self {
-            FeatureEvent::Scenario(_, ref s) => s.failed(),
-            FeatureEvent::Rule(_, ref r) => r.failed(),
-            _ => false,
-        }
-    }
 }
 
 /// Top-level cucumber run event.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub trait World: Sized + UnwindSafe + 'static {
 /// User can replace the default `EventHandler` for a `Cucumber`
 /// at construction time using `Cucumber::with_handler`.
 pub trait EventHandler: 'static {
-    fn handle_event(&mut self, event: event::CucumberEvent);
+    fn handle_event(&mut self, event: &event::CucumberEvent);
 }
 
 pub type PanicError = Box<(dyn Any + Send + 'static)>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ use std::panic::UnwindSafe;
 
 pub use cucumber::Cucumber;
 pub use examples::ExampleValues;
+pub use runner::RunResult;
 use std::any::Any;
 pub use steps::Steps;
 

--- a/src/output/default.rs
+++ b/src/output/default.rs
@@ -174,11 +174,11 @@ impl BasicOutput {
 
     fn handle_step(
         &mut self,
-        feature: Rc<Feature>,
-        rule: Option<Rc<Rule>>,
-        _scenario: Rc<Scenario>,
-        step: Rc<Step>,
-        event: StepEvent,
+        feature: &Rc<Feature>,
+        rule: Option<&Rc<Rule>>,
+        _scenario: &Rc<Scenario>,
+        step: &Rc<Step>,
+        event: &StepEvent,
         is_bg: bool,
     ) {
         let cmt = self.file_line_col(feature.path.as_ref(), step.position);
@@ -341,10 +341,10 @@ impl BasicOutput {
 
     fn handle_scenario(
         &mut self,
-        feature: Rc<Feature>,
-        rule: Option<Rc<Rule>>,
-        scenario: Rc<Scenario>,
-        event: ScenarioEvent,
+        feature: &Rc<Feature>,
+        rule: Option<&Rc<Rule>>,
+        scenario: &Rc<Scenario>,
+        event: &ScenarioEvent,
     ) {
         match event {
             ScenarioEvent::Starting(example_values) => {
@@ -371,10 +371,10 @@ impl BasicOutput {
         }
     }
 
-    fn handle_rule(&mut self, feature: Rc<Feature>, rule: Rc<Rule>, event: RuleEvent) {
+    fn handle_rule(&mut self, feature: &Rc<Feature>, rule: &Rc<Rule>, event: &RuleEvent) {
         if let RuleEvent::Scenario(scenario, evt) = event {
             self.handle_scenario(feature, Some(rule), scenario, evt)
-        } else if event == RuleEvent::Starting {
+        } else if *event == RuleEvent::Starting {
             let cmt = self.file_line_col(feature.path.as_ref(), rule.position);
             self.writeln_cmt(
                 &format!("Rule: {}", &rule.name),
@@ -432,7 +432,7 @@ impl BasicOutput {
 }
 
 impl EventHandler for BasicOutput {
-    fn handle_event(&mut self, event: CucumberEvent) {
+    fn handle_event(&mut self, event: &CucumberEvent) {
         match event {
             CucumberEvent::Starting => {
                 cprintln!(bold termcolor::Color::Blue, "[Cucumber v{}]", env!("CARGO_PKG_VERSION"))

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -21,7 +21,7 @@ struct CustomEventHandlerState {
     any_step_timeouts: bool,
 }
 impl EventHandler for CustomEventHandler {
-    fn handle_event(&mut self, event: CucumberEvent) {
+    fn handle_event(&mut self, event: &CucumberEvent) {
         let mut state = self.state.lock().unwrap();
         match event {
             CucumberEvent::Feature(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -120,7 +120,12 @@ fn user_defined_event_handlers_are_expressible() {
         .features(&["./features/integration"])
         .step_timeout(Duration::from_secs(1));
 
-    futures::executor::block_on(runner.run());
+    let results = futures::executor::block_on(runner.run());
+
+    assert_eq!(results.features.total, 1);
+    assert_eq!(results.steps.total, 14);
+    assert_eq!(results.steps.passed, 4);
+    assert_eq!(results.scenarios.failed, 1);
 
     let handler_state = custom_handler.state.lock().unwrap();
     assert!(!handler_state.any_rule_failures);
@@ -129,6 +134,7 @@ fn user_defined_event_handlers_are_expressible() {
     assert!(handler_state.any_step_success);
     assert!(handler_state.any_scenario_skipped);
     assert!(handler_state.any_step_timeouts);
+
 }
 
 fn nocapture_enabled() -> bool {


### PR DESCRIPTION
Currently when running `Cucumber..run()` nothing it reported back to the caller. This changes this behavior by making the result value a `result` with either `()` in the regular case (arguably could be the number of successes or something) and `u64` if any errors have been found. This number also equals the total number of failure found.

To implement this a handy function `failed()` is added to the various events allowing for checking down the tree whether the currently reported item reports a failure or not. All functions have minimal rustdoc documentation added. 