### PR TITLE
Fix to use correct API on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,12 @@ fn main() {
 
     let runner = cucumber::Cucumber::<MyWorld>::new()
         .features(&["./features"])
-        .steps(example_steps::steps())
-        .cli();
+        .steps(example_steps::steps());
 
     // You may choose any executor you like (Tokio, async-std, etc)
     // You may even have an async main, it doesn't matter. The point is that
     // Cucumber is composable. :)
-    futures::executor::block_on(runner.run_and_exit());
+    futures::executor::block_on(runner.run());
 }
 ```
 


### PR DESCRIPTION
Hi, I just started, followed the readme guide, and found that it causes two trivial errors that depend on the old version. It's very trivial, but I hope it helps.